### PR TITLE
feat: add DC018/DC019 compile-time kernel safety analyzers for v1.0.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ DotCompute/
 
 **Developer Tooling**:
 - ✅ Source Generators ([Kernel] attribute → auto-optimization)
-- ✅ Roslyn Analyzers (12 diagnostic rules DC001-DC012)
+- ✅ Roslyn Analyzers (19 diagnostic rules DC001-DC019; DC013-DC017 cover RingKernel/Telemetry, DC018/DC019 cover v1.0.0 type-safety gotchas — unmanaged constraint and buffer aliasing)
 - ✅ IDE Integration (5 automated code fixes, real-time feedback)
 - ✅ Cross-Backend Debugging (CPU vs GPU validation)
 - ✅ Adaptive Optimization (ML-powered backend selection)

--- a/docs/articles/reference/diagnostic-rules.md
+++ b/docs/articles/reference/diagnostic-rules.md
@@ -1,6 +1,6 @@
 # Diagnostic Rules Reference
 
-Complete reference for DotCompute analyzer diagnostics (DC001-DC012) with automated code fixes.
+Complete reference for DotCompute analyzer diagnostics (DC001-DC019) with automated code fixes.
 
 ## Overview
 
@@ -511,6 +511,85 @@ public static void ProcessData(ReadOnlySpan<float> input, Span<float> output)
 ```
 
 **Rationale**: Public APIs should be documented for maintainability.
+
+---
+
+## Type-Safety Rules (v1.0.0)
+
+### DC018: Kernel Type Parameter Must Be 'unmanaged'
+
+**Severity**: Error
+**Category**: DotCompute.Kernel
+
+**Description**: A method marked with `[Kernel]` declares one or more generic type parameters without an `unmanaged` constraint. Kernels run on GPU memory and cannot handle managed references, so this must be enforced at compile-time.
+
+**Example — failing**:
+```csharp
+[Kernel]
+public static void ScaleKernel<T>(Span<T> data)   // DC018: T lacks 'unmanaged'
+{
+    int idx = Kernel.ThreadId.X;
+    if (idx < data.Length) data[idx] = default;
+}
+```
+
+**Fix**: add the `unmanaged` constraint.
+```csharp
+[Kernel]
+public static void ScaleKernel<T>(Span<T> data)
+    where T : unmanaged                            // correct
+{
+    int idx = Kernel.ThreadId.X;
+    if (idx < data.Length) data[idx] = default;
+}
+```
+
+**Note**: `where T : struct` is **not** sufficient. A `struct` may contain managed references (e.g. `string`), which still break GPU layout. Only `unmanaged` guarantees the type has no managed fields transitively.
+
+**Rationale**: Moving the diagnostic from kernel-launch time (cryptic runtime error) to compile-time (clear editor squiggle) dramatically improves the debugging experience for kernel authors.
+
+---
+
+### DC019: Potential Buffer Aliasing in Kernel Call
+
+**Severity**: Warning
+**Category**: DotCompute.Reliability
+
+**Description**: A kernel launch (`IComputeOrchestrator.ExecuteAsync` / `ICompiledKernel.LaunchAsync` / `ExecuteWithBuffersAsync`) receives the same buffer reference for two or more parameters. Most GPU kernels assume non-overlapping buffers; aliasing causes undefined behavior or data corruption at runtime.
+
+**Example — failing**:
+```csharp
+var buf = memory.Allocate<float>(1024);
+await orchestrator.ExecuteAsync<object>("vector_add", buf, buf, buf);  // DC019
+```
+
+**Fix — option 1**: pass distinct buffers.
+```csharp
+var a = memory.Allocate<float>(1024);
+var b = memory.Allocate<float>(1024);
+var c = memory.Allocate<float>(1024);
+await orchestrator.ExecuteAsync<object>("vector_add", a, b, c);        // OK
+```
+
+**Fix — option 2**: acknowledge in-place intent with `[AliasAllowed]` on the enclosing method.
+```csharp
+[AliasAllowed]
+public async Task RunInPlace(IComputeOrchestrator orchestrator, IUnifiedMemoryBuffer buf)
+{
+    // Same buffer for in/out is the whole point of an in-place op.
+    await orchestrator.ExecuteAsync<object>("normalize_inplace", buf, buf);
+}
+```
+
+**Note**: The `[AliasAllowed]` attribute is recognized by name. If your project does not yet define it, declare a no-op:
+```csharp
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
+public sealed class AliasAllowedAttribute : Attribute { }
+```
+
+**Scope**: only identifier and member-access arguments are considered — literal scalars (e.g. `0`, `"name"`) are never flagged.
+
+**Rationale**: DC019 is a *warning*, not an *error*, because self-aliasing is legitimate for in-place operations. The warning forces kernel authors to make that intent explicit.
 
 ---
 

--- a/src/Runtime/DotCompute.Generators/AnalyzerReleases.Unshipped.md
+++ b/src/Runtime/DotCompute.Generators/AnalyzerReleases.Unshipped.md
@@ -27,3 +27,5 @@ DC014 | DotCompute.Telemetry | Warning | Telemetry polling interval is too frequ
 DC015 | DotCompute.Telemetry | Error | Telemetry must be enabled before polling
 DC016 | DotCompute.Telemetry | Error | Telemetry cannot be enabled before kernel launch
 DC017 | DotCompute.Telemetry | Warning | Telemetry reset requires enabled telemetry
+DC018 | DotCompute.Kernel | Error | Kernel type parameter must be 'unmanaged'
+DC019 | DotCompute.Reliability | Warning | Potential buffer aliasing in kernel call

--- a/src/Runtime/DotCompute.Generators/Analyzers/KernelDiagnostics.cs
+++ b/src/Runtime/DotCompute.Generators/Analyzers/KernelDiagnostics.cs
@@ -185,4 +185,25 @@ public static class KernelDiagnostics
         isEnabledByDefault: true,
         description: "ResetTelemetryAsync requires an allocated telemetry buffer. If telemetry is not enabled, the reset operation will throw InvalidOperationException. Enable telemetry with SetTelemetryEnabledAsync(true) before calling ResetTelemetryAsync."
     );
+
+    // Kernel Type Safety Issues (DC018-DC019) — v1.0.0 compile-time safety for kernel authors
+    public static readonly DiagnosticDescriptor KernelGenericParameterMustBeUnmanaged = new(
+        "DC018",
+        "Kernel type parameter must be 'unmanaged'",
+        "[Kernel] method '{0}' uses type parameter '{1}' without an 'unmanaged' constraint. Add 'where {1} : unmanaged' to the method signature.",
+        "DotCompute.Kernel",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Kernel type parameters must be constrained to 'unmanaged' because kernels execute on GPU memory and cannot handle managed references. Without this constraint, code that compiles fine will fail at kernel-launch time with a cryptic runtime error. Adding 'where T : unmanaged' moves the diagnostic to compile-time."
+    );
+
+    public static readonly DiagnosticDescriptor KernelPotentialBufferAliasing = new(
+        "DC019",
+        "Potential buffer aliasing in kernel call",
+        "Buffer '{0}' is passed to multiple parameters of kernel call. If intentional (in-place operation), annotate with [AliasAllowed]; otherwise use separate buffers.",
+        "DotCompute.Reliability",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Most GPU kernels assume non-overlapping buffer parameters. Passing the same buffer reference for multiple arguments can cause undefined behavior or data corruption at runtime. If aliasing is intentional (e.g., in-place operations), annotate the call site with [AliasAllowed] or restructure the call to use distinct buffers."
+    );
 }

--- a/src/Runtime/DotCompute.Generators/Analyzers/KernelTypeSafetyAnalyzer.cs
+++ b/src/Runtime/DotCompute.Generators/Analyzers/KernelTypeSafetyAnalyzer.cs
@@ -1,0 +1,351 @@
+// Copyright (c) 2025 Michael Ivertowski
+// Licensed under the MIT License. See LICENSE file in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace DotCompute.Generators.Analyzers;
+
+/// <summary>
+/// Roslyn analyzer for kernel type-safety gotchas that are hard contracts at runtime
+/// but easy to catch at compile-time.
+/// </summary>
+/// <remarks>
+/// <para>Reports the following diagnostics:</para>
+/// <list type="bullet">
+/// <item><description><b>DC018</b> — Kernel type parameters must have an <c>unmanaged</c> constraint.</description></item>
+/// <item><description><b>DC019</b> — Potential buffer aliasing when the same buffer is passed to multiple kernel arguments.</description></item>
+/// </list>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class KernelTypeSafetyAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc />
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
+        KernelDiagnostics.KernelGenericParameterMustBeUnmanaged,
+        KernelDiagnostics.KernelPotentialBufferAliasing
+    );
+
+    /// <inheritdoc />
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        // DC018: Inspect each method declaration for [Kernel] + missing 'unmanaged' constraints.
+        context.RegisterSyntaxNodeAction(AnalyzeMethodForUnmanagedConstraint, SyntaxKind.MethodDeclaration);
+
+        // DC019: Inspect each invocation for repeated buffer arguments passed to a kernel call.
+        context.RegisterSyntaxNodeAction(AnalyzeInvocationForBufferAliasing, SyntaxKind.InvocationExpression);
+    }
+
+    // ---------- DC018: Kernel type parameter must be unmanaged ----------
+
+    private static void AnalyzeMethodForUnmanagedConstraint(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is not MethodDeclarationSyntax methodSyntax)
+        {
+            return;
+        }
+
+        // Only type parameters on generic methods can be constrained per-method.
+        if (methodSyntax.TypeParameterList is null || methodSyntax.TypeParameterList.Parameters.Count == 0)
+        {
+            return;
+        }
+
+        if (context.SemanticModel.GetDeclaredSymbol(methodSyntax) is not IMethodSymbol methodSymbol)
+        {
+            return;
+        }
+
+        if (!KernelAnalysisHelpers.HasKernelAttribute(methodSymbol))
+        {
+            return;
+        }
+
+        // Collect the set of type parameters actually referenced in the signature.
+        // If a type parameter is declared but unused, we still flag it — its mere
+        // presence on a [Kernel] method is a contract violation if callers can bind
+        // it to a managed type.
+        foreach (var typeParameter in methodSymbol.TypeParameters)
+        {
+            if (typeParameter.HasUnmanagedTypeConstraint)
+            {
+                continue;
+            }
+
+            var parameterSyntax = methodSyntax.TypeParameterList.Parameters
+                .FirstOrDefault(p => p.Identifier.ValueText == typeParameter.Name);
+
+            var location = parameterSyntax?.GetLocation() ?? methodSyntax.Identifier.GetLocation();
+
+            var diagnostic = Diagnostic.Create(
+                KernelDiagnostics.KernelGenericParameterMustBeUnmanaged,
+                location,
+                methodSymbol.Name,
+                typeParameter.Name);
+
+            context.ReportDiagnostic(diagnostic);
+        }
+    }
+
+    // ---------- DC019: Potential buffer aliasing in kernel call ----------
+
+    private static void AnalyzeInvocationForBufferAliasing(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is not InvocationExpressionSyntax invocation)
+        {
+            return;
+        }
+
+        if (!IsKernelLaunchInvocation(invocation, out var firstArgIndex))
+        {
+            return;
+        }
+
+        // Suppress if the enclosing method or type carries [AliasAllowed].
+        if (HasAliasAllowedAttribute(context, invocation))
+        {
+            return;
+        }
+
+        // Track distinct buffer-shaped arguments by their text; whenever the same
+        // syntactic expression appears twice for a kernel-call invocation, report.
+        var seen = new Dictionary<string, ArgumentSyntax>(System.StringComparer.Ordinal);
+
+        var arguments = invocation.ArgumentList.Arguments;
+        for (var i = firstArgIndex; i < arguments.Count; i++)
+        {
+            var argument = arguments[i];
+            var expression = argument.Expression;
+
+            if (!LooksLikeBufferArgument(expression))
+            {
+                continue;
+            }
+
+            var normalized = expression.ToString();
+
+            if (seen.TryGetValue(normalized, out var firstOccurrence))
+            {
+                var diagnostic = Diagnostic.Create(
+                    KernelDiagnostics.KernelPotentialBufferAliasing,
+                    argument.GetLocation(),
+                    additionalLocations: new[] { firstOccurrence.GetLocation() },
+                    normalized);
+
+                context.ReportDiagnostic(diagnostic);
+            }
+            else
+            {
+                seen[normalized] = argument;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Determines whether an invocation expression represents a kernel launch / execute call
+    /// (IComputeOrchestrator.ExecuteAsync or ICompiledKernel.LaunchAsync family).
+    /// </summary>
+    /// <param name="invocation">The invocation expression.</param>
+    /// <param name="firstArgIndex">
+    /// Out: the index of the first argument that represents a kernel parameter
+    /// (ExecuteAsync's kernel name / preferred backend / accelerator are skipped).
+    /// </param>
+    private static bool IsKernelLaunchInvocation(InvocationExpressionSyntax invocation, out int firstArgIndex)
+    {
+        firstArgIndex = 0;
+
+        var methodName = GetInvokedMethodName(invocation);
+        if (methodName is null)
+        {
+            return false;
+        }
+
+        switch (methodName)
+        {
+            case "ExecuteAsync":
+                // orchestrator.ExecuteAsync("name", args...)
+                // orchestrator.ExecuteAsync("name", preferredBackendOrAccelerator, args...)
+                firstArgIndex = DetermineExecuteAsyncFirstArgIndex(invocation);
+                return firstArgIndex >= 0;
+            case "ExecuteWithBuffersAsync":
+                // orchestrator.ExecuteWithBuffersAsync("name", buffers, scalarArgs...)
+                // The buffers parameter itself is IEnumerable; skip first two slots.
+                firstArgIndex = 2;
+                return invocation.ArgumentList.Arguments.Count >= 2;
+            case "LaunchAsync":
+                // ICompiledKernel.LaunchAsync or IRingKernelRuntime.LaunchAsync.
+                // We conservatively scan *all* arguments; buffer-shaped ones rise to the
+                // top via LooksLikeBufferArgument().
+                firstArgIndex = 0;
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static int DetermineExecuteAsyncFirstArgIndex(InvocationExpressionSyntax invocation)
+    {
+        var args = invocation.ArgumentList.Arguments;
+        if (args.Count == 0)
+        {
+            return -1;
+        }
+
+        // First positional argument is always the kernel name.
+        // The second positional argument *may* be an accelerator or preferred-backend
+        // string; if it's a string literal or looks like an identifier, skip it too.
+        if (args.Count >= 2 && IsLikelyBackendOrAcceleratorArgument(args[1].Expression))
+        {
+            return 2;
+        }
+
+        return 1;
+    }
+
+    private static bool IsLikelyBackendOrAcceleratorArgument(ExpressionSyntax expression)
+    {
+        // String literal for preferred-backend overload.
+        if (expression is LiteralExpressionSyntax literal && literal.IsKind(SyntaxKind.StringLiteralExpression))
+        {
+            return true;
+        }
+
+        // A bare identifier named something like "accelerator" or "backend" is
+        // a strong heuristic; without semantic info we lean conservative.
+        if (expression is IdentifierNameSyntax id)
+        {
+            var name = id.Identifier.ValueText;
+            if (name.IndexOf("accelerator", System.StringComparison.OrdinalIgnoreCase) >= 0 ||
+                name.IndexOf("backend", System.StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string? GetInvokedMethodName(InvocationExpressionSyntax invocation)
+    {
+        return invocation.Expression switch
+        {
+            MemberAccessExpressionSyntax memberAccess => memberAccess.Name.Identifier.ValueText,
+            IdentifierNameSyntax id => id.Identifier.ValueText,
+            GenericNameSyntax generic => generic.Identifier.ValueText,
+            _ => null
+        };
+    }
+
+    /// <summary>
+    /// Heuristically determines whether an argument expression looks like a buffer reference
+    /// (identifier, member access, or simple cast), as opposed to a scalar literal or constant.
+    /// </summary>
+    private static bool LooksLikeBufferArgument(ExpressionSyntax expression)
+    {
+        // Unwrap casts.
+        while (expression is CastExpressionSyntax cast)
+        {
+            expression = cast.Expression;
+        }
+
+        switch (expression)
+        {
+            case IdentifierNameSyntax:
+            case MemberAccessExpressionSyntax:
+                return true;
+            case LiteralExpressionSyntax:
+                return false;
+            default:
+                return false;
+        }
+    }
+
+    private static bool HasAliasAllowedAttribute(SyntaxNodeAnalysisContext context, InvocationExpressionSyntax invocation)
+    {
+        // Walk outward from the invocation looking for [AliasAllowed] on the
+        // enclosing method, property, or type. We match by simple name so the
+        // attribute doesn't need to exist in this PR to be effective once
+        // introduced.
+        for (SyntaxNode? node = invocation; node is not null; node = node.Parent)
+        {
+            switch (node)
+            {
+                case MethodDeclarationSyntax method:
+                    if (HasAttributeNamed(method.AttributeLists, "AliasAllowed"))
+                    {
+                        return true;
+                    }
+                    break;
+                case PropertyDeclarationSyntax property:
+                    if (HasAttributeNamed(property.AttributeLists, "AliasAllowed"))
+                    {
+                        return true;
+                    }
+                    break;
+                case TypeDeclarationSyntax type:
+                    if (HasAttributeNamed(type.AttributeLists, "AliasAllowed"))
+                    {
+                        return true;
+                    }
+                    break;
+            }
+        }
+
+        // Also check the declared method symbol if available (covers local functions etc.).
+        var enclosingMethod = invocation.FirstAncestorOrSelf<MethodDeclarationSyntax>();
+        if (enclosingMethod is not null &&
+            context.SemanticModel.GetDeclaredSymbol(enclosingMethod) is IMethodSymbol methodSymbol)
+        {
+            if (methodSymbol.GetAttributes().Any(a =>
+                    a.AttributeClass?.Name is "AliasAllowedAttribute" or "AliasAllowed"))
+            {
+                return true;
+            }
+
+            if (methodSymbol.ContainingType?.GetAttributes().Any(a =>
+                    a.AttributeClass?.Name is "AliasAllowedAttribute" or "AliasAllowed") == true)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasAttributeNamed(SyntaxList<AttributeListSyntax> attributeLists, string shortName)
+    {
+        foreach (var list in attributeLists)
+        {
+            foreach (var attr in list.Attributes)
+            {
+                var name = attr.Name switch
+                {
+                    QualifiedNameSyntax q => q.Right.Identifier.ValueText,
+                    IdentifierNameSyntax i => i.Identifier.ValueText,
+                    _ => null
+                };
+
+                if (name is null)
+                {
+                    continue;
+                }
+
+                if (string.Equals(name, shortName, System.StringComparison.Ordinal) ||
+                    string.Equals(name, shortName + "Attribute", System.StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Unit/DotCompute.Generators.Tests/Analyzers/DC018_DC019_AnalyzerTests.cs
+++ b/tests/Unit/DotCompute.Generators.Tests/Analyzers/DC018_DC019_AnalyzerTests.cs
@@ -1,0 +1,386 @@
+// Copyright (c) 2025 Michael Ivertowski
+// Licensed under the MIT License. See LICENSE file in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Linq;
+using DotCompute.Generators.Analyzers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Xunit;
+
+namespace DotCompute.Generators.Tests.Analyzers;
+
+/// <summary>
+/// Tests for diagnostic rules DC018 (kernel type parameter must be 'unmanaged') and
+/// DC019 (potential buffer aliasing in kernel call).
+/// </summary>
+public sealed class DC018_DC019_AnalyzerTests
+{
+    // ===== DC018: Kernel generic type parameter must be 'unmanaged' =====
+
+    [Fact]
+    public void DC018_KernelWithoutUnmanagedConstraint_ProducesError()
+    {
+        const string code = @"
+using System;
+public static class TestClass
+{
+    [Kernel]
+    public static void ScaleKernel<T>(Span<T> data)
+    {
+        int idx = Kernel.ThreadId.X;
+        if (idx < data.Length) { }
+    }
+}
+[System.AttributeUsage(System.AttributeTargets.Method)]
+public class KernelAttribute : System.Attribute { }
+public static class Kernel { public static ThreadId ThreadId => new(); }
+public struct ThreadId { public int X => 0; }";
+
+        var diagnostics = GetDiagnostics(code);
+        var dc018 = diagnostics.FirstOrDefault(d => d.Id == "DC018");
+
+        Assert.NotNull(dc018);
+        Assert.Equal(DiagnosticSeverity.Error, dc018.Severity);
+        Assert.Contains("ScaleKernel", dc018.GetMessage());
+        Assert.Contains("'T'", dc018.GetMessage());
+        Assert.Contains("unmanaged", dc018.GetMessage());
+    }
+
+    [Fact]
+    public void DC018_KernelWithUnmanagedConstraint_NoDiagnostic()
+    {
+        const string code = @"
+using System;
+public static class TestClass
+{
+    [Kernel]
+    public static void ScaleKernel<T>(Span<T> data) where T : unmanaged
+    {
+        int idx = Kernel.ThreadId.X;
+        if (idx < data.Length) { }
+    }
+}
+[System.AttributeUsage(System.AttributeTargets.Method)]
+public class KernelAttribute : System.Attribute { }
+public static class Kernel { public static ThreadId ThreadId => new(); }
+public struct ThreadId { public int X => 0; }";
+
+        var diagnostics = GetDiagnostics(code);
+        Assert.Null(diagnostics.FirstOrDefault(d => d.Id == "DC018"));
+    }
+
+    [Fact]
+    public void DC018_KernelWithOnlyStructConstraint_StillProducesError()
+    {
+        // Edge case from the spec: 'struct' is not equivalent to 'unmanaged'
+        // because struct allows types with managed reference fields (e.g.,
+        // struct S { string Ref; }), which cannot live in GPU memory.
+        const string code = @"
+using System;
+public static class TestClass
+{
+    [Kernel]
+    public static void ScaleKernel<T>(Span<T> data) where T : struct
+    {
+        int idx = Kernel.ThreadId.X;
+        if (idx < data.Length) { }
+    }
+}
+[System.AttributeUsage(System.AttributeTargets.Method)]
+public class KernelAttribute : System.Attribute { }
+public static class Kernel { public static ThreadId ThreadId => new(); }
+public struct ThreadId { public int X => 0; }";
+
+        var diagnostics = GetDiagnostics(code);
+        var dc018 = diagnostics.FirstOrDefault(d => d.Id == "DC018");
+
+        Assert.NotNull(dc018);
+        Assert.Contains("'T'", dc018.GetMessage());
+    }
+
+    [Fact]
+    public void DC018_NonKernelGenericMethod_NoDiagnostic()
+    {
+        const string code = @"
+using System;
+public static class TestClass
+{
+    public static void GenericHelper<T>(Span<T> data) where T : struct
+    {
+        // Not marked with [Kernel] — analyzer must not fire.
+    }
+}
+[System.AttributeUsage(System.AttributeTargets.Method)]
+public class KernelAttribute : System.Attribute { }";
+
+        var diagnostics = GetDiagnostics(code);
+        Assert.Null(diagnostics.FirstOrDefault(d => d.Id == "DC018"));
+    }
+
+    [Fact]
+    public void DC018_KernelWithMultipleGenericParameters_ReportsEachUnconstrainedOne()
+    {
+        const string code = @"
+using System;
+public static class TestClass
+{
+    [Kernel]
+    public static void ConvertKernel<TIn, TOut>(Span<TIn> input, Span<TOut> output)
+        where TOut : unmanaged
+    {
+        int idx = Kernel.ThreadId.X;
+        if (idx < input.Length) { }
+    }
+}
+[System.AttributeUsage(System.AttributeTargets.Method)]
+public class KernelAttribute : System.Attribute { }
+public static class Kernel { public static ThreadId ThreadId => new(); }
+public struct ThreadId { public int X => 0; }";
+
+        var diagnostics = GetDiagnostics(code).Where(d => d.Id == "DC018").ToList();
+
+        Assert.Single(diagnostics);
+        Assert.Contains("'TIn'", diagnostics[0].GetMessage());
+    }
+
+    [Fact]
+    public void DC018_NonGenericKernel_NoDiagnostic()
+    {
+        const string code = @"
+using System;
+public static class TestClass
+{
+    [Kernel]
+    public static void Simple(Span<float> data)
+    {
+        int idx = Kernel.ThreadId.X;
+        if (idx < data.Length) { }
+    }
+}
+[System.AttributeUsage(System.AttributeTargets.Method)]
+public class KernelAttribute : System.Attribute { }
+public static class Kernel { public static ThreadId ThreadId => new(); }
+public struct ThreadId { public int X => 0; }";
+
+        var diagnostics = GetDiagnostics(code);
+        Assert.Null(diagnostics.FirstOrDefault(d => d.Id == "DC018"));
+    }
+
+    [Fact]
+    public void DC018_CodeFix_AppliesUnmanagedConstraint()
+    {
+        // Before: no constraint → DC018 fires.
+        const string before = @"
+using System;
+public static class TestClass
+{
+    [Kernel]
+    public static void ScaleKernel<T>(Span<T> data)
+    {
+        int idx = Kernel.ThreadId.X;
+        if (idx < data.Length) { }
+    }
+}
+[System.AttributeUsage(System.AttributeTargets.Method)]
+public class KernelAttribute : System.Attribute { }
+public static class Kernel { public static ThreadId ThreadId => new(); }
+public struct ThreadId { public int X => 0; }";
+
+        // Apply the fix manually (the fix itself is also exercised as a syntactic
+        // transform — in a production IDE the [DC018CodeFixProvider] would perform
+        // the same edit).
+        var fixedSource = KernelUnmanagedConstraintCodeFixProvider.ApplyFix(before, "ScaleKernel", "T");
+
+        Assert.Contains("where T : unmanaged", fixedSource);
+
+        // After the fix, DC018 must no longer fire.
+        var diagnosticsAfter = GetDiagnostics(fixedSource);
+        Assert.Null(diagnosticsAfter.FirstOrDefault(d => d.Id == "DC018"));
+    }
+
+    // ===== DC019: Potential buffer aliasing in kernel call =====
+
+    [Fact]
+    public void DC019_SameBufferPassedTwiceToExecuteAsync_ProducesWarning()
+    {
+        const string code = @"
+using System.Threading.Tasks;
+
+public interface IComputeOrchestrator
+{
+    Task<T> ExecuteAsync<T>(string kernelName, params object[] args);
+}
+
+public class Caller
+{
+    public async Task Run(IComputeOrchestrator orchestrator, object buf)
+    {
+        await orchestrator.ExecuteAsync<object>(""vector_add"", buf, buf, buf);
+    }
+}";
+
+        var diagnostics = GetDiagnostics(code).Where(d => d.Id == "DC019").ToList();
+
+        Assert.NotEmpty(diagnostics);
+        Assert.All(diagnostics, d => Assert.Equal(DiagnosticSeverity.Warning, d.Severity));
+        Assert.Contains(diagnostics, d => d.GetMessage().Contains("'buf'"));
+    }
+
+    [Fact]
+    public void DC019_DistinctBuffers_NoDiagnostic()
+    {
+        const string code = @"
+using System.Threading.Tasks;
+
+public interface IComputeOrchestrator
+{
+    Task<T> ExecuteAsync<T>(string kernelName, params object[] args);
+}
+
+public class Caller
+{
+    public async Task Run(IComputeOrchestrator orchestrator, object a, object b, object c)
+    {
+        await orchestrator.ExecuteAsync<object>(""vector_add"", a, b, c);
+    }
+}";
+
+        var diagnostics = GetDiagnostics(code).Where(d => d.Id == "DC019").ToList();
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void DC019_AliasAllowedAttribute_SuppressesDiagnostic()
+    {
+        // Even though 'buf' appears twice, the caller has opted-in to aliasing.
+        const string code = @"
+using System.Threading.Tasks;
+
+public interface IComputeOrchestrator
+{
+    Task<T> ExecuteAsync<T>(string kernelName, params object[] args);
+}
+
+public class AliasAllowedAttribute : System.Attribute { }
+
+public class Caller
+{
+    [AliasAllowed]
+    public async Task Run(IComputeOrchestrator orchestrator, object buf)
+    {
+        await orchestrator.ExecuteAsync<object>(""inplace"", buf, buf);
+    }
+}";
+
+        var diagnostics = GetDiagnostics(code).Where(d => d.Id == "DC019").ToList();
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void DC019_ScalarLiteralsNotFlagged()
+    {
+        // Literal arguments — even if repeated — are never buffer aliases.
+        const string code = @"
+using System.Threading.Tasks;
+
+public interface IComputeOrchestrator
+{
+    Task<T> ExecuteAsync<T>(string kernelName, params object[] args);
+}
+
+public class Caller
+{
+    public async Task Run(IComputeOrchestrator orchestrator, object buf)
+    {
+        await orchestrator.ExecuteAsync<object>(""repeated_scalars"", buf, 0, 0, 0);
+    }
+}";
+
+        var diagnostics = GetDiagnostics(code).Where(d => d.Id == "DC019").ToList();
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void DC019_UnrelatedInvocation_NoDiagnostic()
+    {
+        const string code = @"
+using System.Threading.Tasks;
+
+public class Caller
+{
+    public void Other(string a, string b, string c) { }
+
+    public void Run(string x)
+    {
+        // Not a kernel launch — must not fire.
+        Other(x, x, x);
+    }
+}";
+
+        var diagnostics = GetDiagnostics(code).Where(d => d.Id == "DC019").ToList();
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void DC019_LaunchAsyncWithAliasedBuffer_ProducesWarning()
+    {
+        const string code = @"
+using System.Threading.Tasks;
+
+public interface ICompiledKernel
+{
+    ValueTask LaunchAsync(object launchConfig, params object[] arguments);
+}
+
+public class Caller
+{
+    public async Task Run(ICompiledKernel kernel, object cfg, object buf)
+    {
+        await kernel.LaunchAsync(cfg, buf, buf);
+    }
+}";
+
+        var diagnostics = GetDiagnostics(code).Where(d => d.Id == "DC019").ToList();
+        Assert.NotEmpty(diagnostics);
+    }
+
+    // ===== Wiring / meta checks =====
+
+    [Fact]
+    public void KernelTypeSafetyAnalyzer_RegistersBothRules()
+    {
+        var analyzer = new KernelTypeSafetyAnalyzer();
+        var ids = analyzer.SupportedDiagnostics.Select(d => d.Id).ToHashSet();
+
+        Assert.Contains("DC018", ids);
+        Assert.Contains("DC019", ids);
+        Assert.Equal(2, ids.Count);
+    }
+
+    // ===== Helpers =====
+
+    private static ImmutableArray<Diagnostic> GetDiagnostics(string source)
+    {
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var compilation = CSharpCompilation.Create(
+            "test",
+            syntaxTrees: new[] { tree },
+            references: new[]
+            {
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(System.Span<>).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(System.Threading.Tasks.Task).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(System.Threading.Tasks.ValueTask).Assembly.Location),
+            });
+
+        var analyzer = new KernelTypeSafetyAnalyzer();
+        var compilationWithAnalyzers = compilation
+            .WithAnalyzers(ImmutableArray.Create<DiagnosticAnalyzer>(analyzer));
+
+        return compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().Result;
+    }
+}

--- a/tests/Unit/DotCompute.Generators.Tests/Analyzers/KernelUnmanagedConstraintCodeFixProvider.cs
+++ b/tests/Unit/DotCompute.Generators.Tests/Analyzers/KernelUnmanagedConstraintCodeFixProvider.cs
@@ -1,0 +1,55 @@
+// Copyright (c) 2025 Michael Ivertowski
+// Licensed under the MIT License. See LICENSE file in the project root for license information.
+
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace DotCompute.Generators.Tests.Analyzers;
+
+/// <summary>
+/// Test-side implementation of the DC018 code fix ("add 'where T : unmanaged'"). This mirrors
+/// the syntactic edit a full CodeFixProvider would perform in the IDE. The production analyzer
+/// ships without a bundled CodeFixProvider (infrastructure tracked separately — see
+/// SimpleAnalyzerTests.CodeFixProvider_ShouldSupportRequiredDiagnostics), so the test owns the
+/// reference implementation to guarantee the message text the analyzer reports is actionable.
+/// </summary>
+internal static class KernelUnmanagedConstraintCodeFixProvider
+{
+    /// <summary>
+    /// Applies the DC018 fix to <paramref name="source"/>: adds
+    /// <c>where {typeParameterName} : unmanaged</c> to the signature of the method
+    /// named <paramref name="methodName"/>.
+    /// </summary>
+    public static string ApplyFix(string source, string methodName, string typeParameterName)
+    {
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var root = tree.GetRoot();
+
+        var method = root.DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .FirstOrDefault(m => m.Identifier.ValueText == methodName)
+            ?? throw new System.InvalidOperationException(
+                $"No method named '{methodName}' found in source.");
+
+        var newConstraintClause = SyntaxFactory.TypeParameterConstraintClause(
+            SyntaxFactory.IdentifierName(typeParameterName),
+            SyntaxFactory.SingletonSeparatedList<TypeParameterConstraintSyntax>(
+                SyntaxFactory.TypeConstraint(
+                    SyntaxFactory.IdentifierName("unmanaged"))));
+
+        // Preserve existing clauses; append/replace the one for `typeParameterName`.
+        var existingClauses = method.ConstraintClauses;
+        var replacementClauses = existingClauses
+            .Where(c => c.Name.Identifier.ValueText != typeParameterName)
+            .Append(newConstraintClause);
+
+        var newMethod = method
+            .WithConstraintClauses(SyntaxFactory.List(replacementClauses))
+            .NormalizeWhitespace(elasticTrivia: true);
+
+        var newRoot = root.ReplaceNode(method, newMethod);
+        return newRoot.ToFullString();
+    }
+}


### PR DESCRIPTION
## Summary

Adds two new Roslyn analyzer rules to the existing DotCompute analyzer suite to catch two common gotchas for v1.0.0 kernel authors:

- **DC018** (Error, `DotCompute.Kernel`) — `[Kernel]` method declares a generic type parameter without an `unmanaged` constraint. Kernels run on GPU memory and cannot handle managed references; enforcing this at compile-time replaces a cryptic launch-time runtime error.
- **DC019** (Warning, `DotCompute.Reliability`) — the same buffer reference is passed to multiple parameters of a kernel launch call (`IComputeOrchestrator.ExecuteAsync`, `ICompiledKernel.LaunchAsync`, `ExecuteWithBuffersAsync`). Warning-level because in-place ops are legitimate; opt in via `[AliasAllowed]` on the enclosing method or type.

## Ambiguity resolved (diagnostic ID numbering)

The task called the new rules DC013 and DC014. Those IDs (plus DC015-DC017) are already reserved in `AnalyzerReleases.Unshipped.md` for RingKernel / Telemetry rules that were added in a prior change but never propagated to `CLAUDE.md`. This PR uses the next available IDs, **DC018** and **DC019**, rather than colliding with or renumbering existing rules (the scope limit explicitly forbids modifying other analyzer rules). `CLAUDE.md` now documents the full mapping.

## What's new

- `src/Runtime/DotCompute.Generators/Analyzers/KernelTypeSafetyAnalyzer.cs` — new `DiagnosticAnalyzer` hosting both rules, following the same `RegisterSyntaxNodeAction` pattern as `KernelMethodAnalyzer` / `RingKernelTelemetryAnalyzer`.
- `src/Runtime/DotCompute.Generators/Analyzers/KernelDiagnostics.cs` — two new descriptors appended to the existing central registry.
- `src/Runtime/DotCompute.Generators/AnalyzerReleases.Unshipped.md` — DC018/DC019 added to release tracking.
- `docs/articles/reference/diagnostic-rules.md` — "Type-Safety Rules (v1.0.0)" section with examples, fixes, rationale.
- `CLAUDE.md` — analyzer count updated from 12 → 19 (DC013-DC017 RingKernel/Telemetry already present; DC018/DC019 new).

## Tests (14 new, all passing)

- `DC018_DC019_AnalyzerTests.cs` — 3 tests per rule minimum:
  - DC018: positive (no constraint fires error), negative (`where T : unmanaged` silent), edge (`where T : struct` still fires — struct is not unmanaged), multi-generic partial constraint, non-generic kernel silent, non-kernel generic silent, **code-fix apply + re-verify**
  - DC019: positive (3x same buffer fires), negative (distinct buffers silent), `[AliasAllowed]` suppression, scalar literals not flagged, unrelated invocation silent, `LaunchAsync` path, wiring meta check
- `KernelUnmanagedConstraintCodeFixProvider.cs` — test-assembly reference implementation of the DC018 code fix (production CodeFixProvider is deferred per `SimpleAnalyzerTests.CodeFixProvider_ShouldSupportRequiredDiagnostics` — requires separate assembly, infrastructure pending).

## Sample diagnostics captured during tests

- **DC018** (Error): `"[Kernel] method 'ScaleKernel' uses type parameter 'T' without an 'unmanaged' constraint. Add 'where T : unmanaged' to the method signature."`
- **DC019** (Warning): `"Buffer 'buf' is passed to multiple parameters of kernel call. If intentional (in-place operation), annotate with [AliasAllowed]; otherwise use separate buffers."`

## Test plan

- [x] `dotnet build DotCompute.sln --configuration Release` → **0 warnings, 0 errors**
- [x] `dotnet test tests/Unit/DotCompute.Generators.Tests --filter "FullyQualifiedName~DC018_DC019"` → 14/14 pass
- [x] `dotnet test tests/Unit/DotCompute.Generators.Tests --filter "FullyQualifiedName~Analyzers|~SimpleAnalyzerTests|~Comprehensive"` → 65 pass, 1 pre-existing skip (no regressions)
- [x] `grep -rn "DC018\|DC019" src/` shows both rules registered in the descriptor list and analyzer class

## Scope limits honored

- No other analyzer rule bodies modified (DC001-DC017 untouched).
- No source-generator code modified — this is additive to the analyzer surface only.
- No new severity taxonomy — reused existing `DotCompute.Kernel` / `DotCompute.Reliability` categories.
- `[AliasAllowed]` attribute is recognized by simple name — **not** introduced in this PR (per scope note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)