### PR TITLE
test: add 110 unit tests for CpuKernelGenerator (v1.0.0 GA)

### DIFF
--- a/tests/Unit/DotCompute.Linq.Tests/CodeGeneration/CpuKernelGeneratorEdgeCasesTests.cs
+++ b/tests/Unit/DotCompute.Linq.Tests/CodeGeneration/CpuKernelGeneratorEdgeCasesTests.cs
@@ -1,0 +1,674 @@
+// Copyright (c) 2025 Michael Ivertowski
+// Licensed under the MIT License. See LICENSE file in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq.Expressions;
+using DotCompute.Linq.CodeGeneration;
+using DotCompute.Linq.Compilation;
+using DotCompute.Linq.Optimization;
+using FluentAssertions;
+using Xunit;
+
+namespace DotCompute.Linq.Tests.CodeGeneration;
+
+/// <summary>
+/// v1.0.0 Phase 9 — Edge-case and structural unit tests for
+/// <see cref="CpuKernelGenerator"/>. Covers gaps in existing baseline:
+/// the Scan operator, type permutations beyond happy-path, error/diagnostic
+/// paths, and structural code-emission assertions that pin down behavior
+/// the optimizer cares about (vector shape, accumulator type, remainder loop).
+/// </summary>
+/// <remarks>
+/// These tests purposefully do not re-assert what
+/// <c>CpuKernelGeneratorTests.cs</c> already covers — they extend it. Each
+/// test asserts a concrete structural property of the emitted source so a
+/// future refactor that regresses the property fails loudly here rather than
+/// in the integration layer.
+/// </remarks>
+[Trait("Category", "Unit")]
+[Trait("Category", "CodeGeneration")]
+[Trait("Category", "CpuKernelGeneratorEdgeCases")]
+public sealed class CpuKernelGeneratorEdgeCasesTests
+{
+    private readonly CpuKernelGenerator _generator = new();
+
+    #region Scan (prefix sum) operator — zero coverage in baseline
+
+    [Fact]
+    public void Scan_WithoutLambda_EmitsCumulativeLoop()
+    {
+        var graph = CreateGraph(OperationType.Scan);
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("Scan operation");
+        _ = code.Should().Contain("accumulator");
+        _ = code.Should().Contain("output[i] = accumulator;");
+        _ = code.Should().Contain("accumulator += input[i];");
+    }
+
+    [Fact]
+    public void Scan_WithLambda_InlinesTransformBeforeAccumulate()
+    {
+        Expression<Func<int, int>> transform = x => x * 2;
+        var graph = CreateGraph(OperationType.Scan, transform);
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("Scan operation");
+        _ = code.Should().Contain("* 2");
+        _ = code.Should().Contain("accumulator += ");
+    }
+
+    [Fact]
+    public void Scan_IsSequential_DoesNotEmitVectorLoop()
+    {
+        var graph = CreateGraph(OperationType.Scan);
+        var metadata = CreateMetadata<double, double>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        // Scan is inherently sequential — no vectorization should be emitted.
+        _ = code.Should().Contain("sequential by nature");
+        _ = code.Should().NotContain("Vector<double>.Count");
+    }
+
+    [Theory]
+    [InlineData(typeof(int), "int")]
+    [InlineData(typeof(long), "long")]
+    [InlineData(typeof(float), "float")]
+    [InlineData(typeof(double), "double")]
+    [InlineData(typeof(uint), "uint")]
+    [InlineData(typeof(short), "short")]
+    public void Scan_AccumulatorDeclaredWithElementType(Type elementType, string expectedTypeName)
+    {
+        var graph = CreateGraph(OperationType.Scan);
+        var metadata = new TypeMetadata
+        {
+            InputType = elementType,
+            ResultType = elementType,
+            IntermediateTypes = new Dictionary<string, Type>(),
+            IsSimdCompatible = true,
+            RequiresUnsafe = false,
+            HasNullableTypes = false
+        };
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain($"{expectedTypeName} accumulator = default;");
+    }
+
+    [Fact]
+    public void Scan_LoopIteratesEveryInputElement()
+    {
+        var graph = CreateGraph(OperationType.Scan);
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("for (int i = 0; i < input.Length; i++)");
+    }
+
+    [Fact]
+    public void Scan_DefaultAccumulatorInitializedToZero()
+    {
+        var graph = CreateGraph(OperationType.Scan);
+        var metadata = CreateMetadata<float, float>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("float accumulator = default;");
+    }
+
+    [Fact]
+    public void Scan_UnsupportedTypeStillEmitsScalarLoop()
+    {
+        // Scan ignores SIMD capability — should work for any type.
+        var graph = CreateGraph(OperationType.Scan);
+        var metadata = CreateMetadata<decimal, decimal>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("accumulator");
+        _ = code.Should().Contain("output[i] = accumulator");
+    }
+
+    #endregion
+
+    #region Type permutation coverage — Map across every supported primitive
+
+    [Theory]
+    [InlineData(typeof(int), "int")]
+    [InlineData(typeof(long), "long")]
+    [InlineData(typeof(float), "float")]
+    [InlineData(typeof(double), "double")]
+    [InlineData(typeof(uint), "uint")]
+    [InlineData(typeof(ulong), "ulong")]
+    [InlineData(typeof(short), "short")]
+    [InlineData(typeof(ushort), "ushort")]
+    [InlineData(typeof(byte), "byte")]
+    [InlineData(typeof(sbyte), "sbyte")]
+    public void Map_EmitsSignatureForEverySupportedPrimitive(Type elementType, string expectedTypeName)
+    {
+        // Using a no-op expression (param => param) so every element type works.
+        var param = Expression.Parameter(elementType, "x");
+        var lambda = Expression.Lambda(param, param);
+
+        var graph = CreateGraph(OperationType.Map, lambda);
+        var metadata = new TypeMetadata
+        {
+            InputType = elementType,
+            ResultType = elementType,
+            IntermediateTypes = new Dictionary<string, Type>(),
+            IsSimdCompatible = true,
+            RequiresUnsafe = false,
+            HasNullableTypes = false
+        };
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain($"ReadOnlySpan<{expectedTypeName}> input");
+        _ = code.Should().Contain($"Span<{expectedTypeName}> output");
+        // Array-overload must also be materialized.
+        _ = code.Should().Contain($"{expectedTypeName}[] Execute({expectedTypeName}[] input)");
+    }
+
+    [Theory]
+    [InlineData(typeof(int))]
+    [InlineData(typeof(long))]
+    [InlineData(typeof(float))]
+    [InlineData(typeof(double))]
+    public void Reduce_EmitsVectorAccumulatorForPrimitives(Type elementType)
+    {
+        var param = Expression.Parameter(elementType, "x");
+        var lambda = Expression.Lambda(param, param);
+        var graph = CreateGraph(OperationType.Reduce, lambda);
+        var metadata = new TypeMetadata
+        {
+            InputType = elementType,
+            ResultType = elementType,
+            IntermediateTypes = new Dictionary<string, Type>(),
+            IsSimdCompatible = true,
+            RequiresUnsafe = false,
+            HasNullableTypes = false
+        };
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        // Must emit a zero-initialized vector accumulator of element type.
+        var typeName = GetName(elementType);
+        _ = code.Should().Contain($"Vector<{typeName}>.Zero");
+        _ = code.Should().Contain($"Vector<{typeName}>.Count");
+    }
+
+    [Theory]
+    [InlineData(typeof(byte))]
+    [InlineData(typeof(sbyte))]
+    [InlineData(typeof(short))]
+    [InlineData(typeof(ushort))]
+    public void Reduce_SmallIntegerTypes_EmitSimdPath(Type elementType)
+    {
+        var param = Expression.Parameter(elementType, "x");
+        var lambda = Expression.Lambda(param, param);
+        var graph = CreateGraph(OperationType.Reduce, lambda);
+        var metadata = new TypeMetadata
+        {
+            InputType = elementType,
+            ResultType = elementType,
+            IntermediateTypes = new Dictionary<string, Type>(),
+            IsSimdCompatible = true,
+            RequiresUnsafe = false,
+            HasNullableTypes = false
+        };
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        // Reduce explicitly supports all primitives — vectorized path expected.
+        var typeName = GetName(elementType);
+        _ = code.Should().Contain($"new Vector<{typeName}>(input.Slice(i))");
+    }
+
+    #endregion
+
+    #region Unsupported / complex-type behavior
+
+    [Fact]
+    public void Map_ComplexStructType_FallsBackToScalarLoop()
+    {
+        // DateTime is not in the SIMD-supported primitive set — generator should emit scalar only.
+        Expression<Func<DateTime, DateTime>> lambda = x => x;
+        var graph = CreateGraph(OperationType.Map, lambda);
+        var metadata = CreateMetadata<DateTime, DateTime>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        // No Vector<DateTime>-qualified code should appear.
+        _ = code.Should().NotContain("Vector<DateTime>");
+        // Scalar loop shape.
+        _ = code.Should().Contain("for (int i = 0; i < input.Length; i++)");
+    }
+
+    [Fact]
+    public void Map_StringType_FallsBackToScalarLoop()
+    {
+        Expression<Func<string, string>> lambda = s => s;
+        var graph = CreateGraph(OperationType.Map, lambda);
+        var metadata = CreateMetadata<string, string>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().NotContain("Vector<string>");
+        _ = code.Should().Contain("ReadOnlySpan<string> input");
+    }
+
+    [Fact]
+    public void Reduce_NonPrimitiveType_UsesScalarReducePath()
+    {
+        Expression<Func<decimal, decimal>> lambda = x => x;
+        var graph = CreateGraph(OperationType.Reduce, lambda);
+        var metadata = CreateMetadata<decimal, decimal>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        // Non-primitive types fall out of the C#-keyword map in GetTypeName and
+        // render via Type.Name ("Decimal"). Both forms are valid C#; the important
+        // property is that no Vector<T> accumulator is emitted.
+        _ = code.Should().Contain("Decimal result = default;");
+        _ = code.Should().NotContain("Vector<");
+    }
+
+    #endregion
+
+    #region Edge-case input shapes
+
+    [Fact]
+    public void Map_WithoutLambda_FallsBackToIdentityCopy()
+    {
+        var op = new Operation
+        {
+            Id = "map-no-lambda",
+            Type = OperationType.Map,
+            Metadata = new Dictionary<string, object>()
+        };
+        var graph = new OperationGraph { Operations = new Collection<Operation> { op } };
+        var metadata = CreateMetadata<decimal, decimal>(); // non-SIMD to force scalar path
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        // Scalar map path with no lambda copies input directly.
+        _ = code.Should().Contain("output[i] = input[i];");
+    }
+
+    [Fact]
+    public void Reduce_WithoutLambda_AccumulatesInputDirectly()
+    {
+        var op = new Operation
+        {
+            Id = "reduce-no-lambda",
+            Type = OperationType.Reduce,
+            Metadata = new Dictionary<string, object>()
+        };
+        var graph = new OperationGraph { Operations = new Collection<Operation> { op } };
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("accumulator += vec;");
+        _ = code.Should().Contain("result += input[i];");
+    }
+
+    [Fact]
+    public void Aggregate_DispatchedToReducePath()
+    {
+        // OperationType.Aggregate and OperationType.Reduce must emit identical structure.
+        Expression<Func<float, float>> lambda = x => x;
+        var graph = CreateGraph(OperationType.Aggregate, lambda);
+        var metadata = CreateMetadata<float, float>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("Reduce operation");
+        _ = code.Should().Contain("Vector<float>.Zero");
+    }
+
+    [Fact]
+    public void Filter_EmitsOutputIndexWriteAndPredicate()
+    {
+        Expression<Func<int, bool>> predicate = x => x > 10;
+        var graph = CreateGraph(OperationType.Filter, predicate);
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("int outputIndex = 0;");
+        _ = code.Should().Contain("output[outputIndex++] = input[i];");
+        _ = code.Should().Contain("> 10");
+    }
+
+    [Fact]
+    public void Filter_WithoutLambda_ThrowsInvalidOperation()
+    {
+        var op = new Operation
+        {
+            Id = "filter-no-lambda",
+            Type = OperationType.Filter,
+            Metadata = new Dictionary<string, object>()
+        };
+        var graph = new OperationGraph { Operations = new Collection<Operation> { op } };
+        var metadata = CreateMetadata<int, int>();
+
+        var act = () => _generator.GenerateKernel(graph, metadata);
+
+        _ = act.Should().Throw<InvalidOperationException>()
+               .WithMessage("*Filter*does not have a Lambda*");
+    }
+
+    #endregion
+
+    #region Structural / emission guarantees
+
+    [Fact]
+    public void Map_SimdPath_EmitsVectorizedThenScalarRemainder()
+    {
+        Expression<Func<int, int>> lambda = x => x + 1;
+        var graph = CreateGraph(OperationType.Map, lambda);
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("Vectorized main loop");
+        _ = code.Should().Contain("Scalar remainder loop");
+        // Remainder must run only on tail.
+        _ = code.Should().Contain("for (; i < input.Length; i++)");
+    }
+
+    [Fact]
+    public void Map_SimdPath_EmitsVectorConstruction()
+    {
+        Expression<Func<float, float>> lambda = x => x * 1.5f;
+        var graph = CreateGraph(OperationType.Map, lambda);
+        var metadata = CreateMetadata<float, float>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("new Vector<float>(input.Slice(i))");
+        _ = code.Should().Contain("result.CopyTo(output.Slice(i));");
+    }
+
+    [Fact]
+    public void Map_SimdPath_UsesVectorConstantForScalarOperand()
+    {
+        // Vector constant-wrapping is a load-bearing codegen contract —
+        // if this breaks, vectorized kernels silently compile to scalar fallbacks.
+        Expression<Func<int, int>> lambda = x => x * 7;
+        var graph = CreateGraph(OperationType.Map, lambda);
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("new Vector<int>(");
+        _ = code.Should().Contain("* new Vector<int>(7)");
+    }
+
+    [Fact]
+    public void Reduce_HorizontalSum_IteratesAllLanes()
+    {
+        Expression<Func<int, int>> lambda = x => x;
+        var graph = CreateGraph(OperationType.Reduce, lambda);
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("for (int lane = 0; lane < vectorSize; lane++)");
+        _ = code.Should().Contain("result += accumulator[lane];");
+    }
+
+    [Fact]
+    public void Reduce_WritesResultToFirstOutputSlot()
+    {
+        Expression<Func<int, int>> lambda = x => x;
+        var graph = CreateGraph(OperationType.Reduce, lambda);
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("output[0] = result;");
+    }
+
+    [Fact]
+    public void Reduce_WithMapLambda_AppliesTransformInsideVectorLoop()
+    {
+        Expression<Func<int, int>> lambda = x => x * x;
+        var graph = CreateGraph(OperationType.Reduce, lambda);
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        // vec reassigned with the transform before accumulation.
+        _ = code.Should().Contain("vec = (vec * vec);");
+        _ = code.Should().Contain("accumulator += vec;");
+    }
+
+    [Fact]
+    public void Map_ConstantSuffix_IsTypeCorrect_ForFloat()
+    {
+        Expression<Func<float, float>> lambda = x => x + 2.5f;
+        var graph = CreateGraph(OperationType.Map, lambda);
+        var metadata = CreateMetadata<float, float>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        // Float constants must carry the 'f' suffix to prevent double-promotion.
+        _ = code.Should().Contain("2.5f");
+    }
+
+    [Fact]
+    public void Map_ConstantSuffix_IsTypeCorrect_ForLong()
+    {
+        Expression<Func<long, long>> lambda = x => x + 100L;
+        var graph = CreateGraph(OperationType.Map, lambda);
+        var metadata = CreateMetadata<long, long>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        // Long constants must carry the 'L' suffix.
+        _ = code.Should().Contain("100L");
+    }
+
+    [Fact]
+    public void Map_ConstantSuffix_IsTypeCorrect_ForDouble()
+    {
+        Expression<Func<double, double>> lambda = x => x * 3.14;
+        var graph = CreateGraph(OperationType.Map, lambda);
+        var metadata = CreateMetadata<double, double>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("3.14d");
+    }
+
+    #endregion
+
+    #region Generated output envelope
+
+    [Fact]
+    public void AnyOperator_EmitsGeneratedKernelClass()
+    {
+        var graph = CreateGraph(OperationType.Map, (Expression<Func<int, int>>)(x => x));
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("namespace DotCompute.Linq.Generated;");
+        _ = code.Should().Contain("public static class GeneratedKernel");
+    }
+
+    [Fact]
+    public void AnyOperator_EmitsArrayOverload_WithMatchingOutputAllocation()
+    {
+        var graph = CreateGraph(OperationType.Map, (Expression<Func<int, double>>)(x => x * 1.5));
+        var metadata = CreateMetadata<int, double>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        // Array-based overload delegates to Span overload.
+        _ = code.Should().Contain("public static double[] Execute(int[] input)");
+        _ = code.Should().Contain("var output = new double[input.Length];");
+        _ = code.Should().Contain("Execute(input.AsSpan(), output.AsSpan());");
+        _ = code.Should().Contain("return output;");
+    }
+
+    [Fact]
+    public void AnyOperator_EmitsAllRequiredUsings()
+    {
+        var graph = CreateGraph(OperationType.Reduce, (Expression<Func<int, int>>)(x => x));
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("using System;");
+        _ = code.Should().Contain("using System.Numerics;");
+        _ = code.Should().Contain("using System.Runtime.Intrinsics;");
+        _ = code.Should().Contain("using System.Threading.Tasks;");
+        _ = code.Should().Contain("using System.Collections.Concurrent;");
+    }
+
+    [Fact]
+    public void Generator_IsReusable_ProducesConsistentOutputOnRepeatedCalls()
+    {
+        // Generator keeps internal state (_builder, _indentLevel, _tempVarCounter)
+        // but clears it per call. Must be safe to reuse.
+        var graph = CreateGraph(OperationType.Map, (Expression<Func<int, int>>)(x => x + 1));
+        var metadata = CreateMetadata<int, int>();
+
+        var first = _generator.GenerateKernel(graph, metadata);
+        var second = _generator.GenerateKernel(graph, metadata);
+
+        _ = second.Should().Be(first);
+    }
+
+    [Fact]
+    public void Generator_HandlesDifferentInputAndOutputTypes()
+    {
+        // int → double projection.
+        Expression<Func<int, double>> lambda = x => (double)x;
+        var graph = CreateGraph(OperationType.Map, lambda);
+        var metadata = CreateMetadata<int, double>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("ReadOnlySpan<int> input");
+        _ = code.Should().Contain("Span<double> output");
+    }
+
+    #endregion
+
+    #region Invalid graphs / argument validation
+
+    [Fact]
+    public void GenerateKernel_NullGraph_Throws()
+    {
+        var metadata = CreateMetadata<int, int>();
+
+        var act = () => _generator.GenerateKernel(null!, metadata);
+
+        _ = act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void GenerateKernel_NullMetadata_Throws()
+    {
+        var graph = CreateGraph(OperationType.Map, (Expression<Func<int, int>>)(x => x));
+
+        var act = () => _generator.GenerateKernel(graph, null!);
+
+        _ = act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void GenerateKernel_EmptyGraph_ThrowsWithMessage()
+    {
+        var graph = new OperationGraph { Operations = new Collection<Operation>() };
+        var metadata = CreateMetadata<int, int>();
+
+        var act = () => _generator.GenerateKernel(graph, metadata);
+
+        _ = act.Should().Throw<InvalidOperationException>()
+               .WithMessage("*no operations*");
+    }
+
+    [Fact]
+    public void GenerateKernel_InvalidOperationTypeInGraph_ThrowsWithMessage()
+    {
+        // An undefined enum value surfaces through ValidateGraph.
+        var op = new Operation
+        {
+            Id = "bad",
+            Type = (OperationType)9999,
+            Metadata = new Dictionary<string, object>()
+        };
+        var graph = new OperationGraph { Operations = new Collection<Operation> { op } };
+        var metadata = CreateMetadata<int, int>();
+
+        var act = () => _generator.GenerateKernel(graph, metadata);
+
+        _ = act.Should().Throw<InvalidOperationException>()
+               .WithMessage("*invalid operation type*");
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static OperationGraph CreateGraph(OperationType type, LambdaExpression? lambda = null)
+    {
+        var metadata = new Dictionary<string, object>();
+        if (lambda != null)
+        {
+            metadata["Lambda"] = lambda;
+        }
+
+        var op = new Operation
+        {
+            Id = "op",
+            Type = type,
+            Metadata = metadata
+        };
+
+        return new OperationGraph { Operations = new Collection<Operation> { op } };
+    }
+
+    private static TypeMetadata CreateMetadata<TInput, TOutput>()
+    {
+        return new TypeMetadata
+        {
+            InputType = typeof(TInput),
+            ResultType = typeof(TOutput),
+            IntermediateTypes = new Dictionary<string, Type>(),
+            IsSimdCompatible = true,
+            RequiresUnsafe = false,
+            HasNullableTypes = false
+        };
+    }
+
+    private static string GetName(Type type) => type switch
+    {
+        Type t when t == typeof(int) => "int",
+        Type t when t == typeof(long) => "long",
+        Type t when t == typeof(float) => "float",
+        Type t when t == typeof(double) => "double",
+        Type t when t == typeof(uint) => "uint",
+        Type t when t == typeof(ulong) => "ulong",
+        Type t when t == typeof(short) => "short",
+        Type t when t == typeof(ushort) => "ushort",
+        Type t when t == typeof(byte) => "byte",
+        Type t when t == typeof(sbyte) => "sbyte",
+        _ => type.Name
+    };
+
+    #endregion
+}

--- a/tests/Unit/DotCompute.Linq.Tests/CodeGeneration/CpuKernelGeneratorOperatorTests.cs
+++ b/tests/Unit/DotCompute.Linq.Tests/CodeGeneration/CpuKernelGeneratorOperatorTests.cs
@@ -1,0 +1,754 @@
+// Copyright (c) 2025 Michael Ivertowski
+// Licensed under the MIT License. See LICENSE file in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq.Expressions;
+using DotCompute.Linq.CodeGeneration;
+using DotCompute.Linq.Compilation;
+using DotCompute.Linq.Optimization;
+using FluentAssertions;
+using Xunit;
+
+namespace DotCompute.Linq.Tests.CodeGeneration;
+
+/// <summary>
+/// v1.0.0 Phase 9 — Structural unit tests for <see cref="CpuKernelGenerator"/>
+/// focused on the OrderBy / GroupBy / Join operators. Extends the Phase 8 tests
+/// in <c>JoinGroupByOrderByTests.cs</c> with deeper coverage of metadata-driven
+/// behavior (Descending, Aggregation kind), lambda key-selectors, type
+/// permutations, and default-branch fallback.
+/// </summary>
+/// <remarks>
+/// The CPU generator chose a different shape per operator (Array.Sort for
+/// OrderBy, Dictionary for GroupBy, HashSet for Join). These tests pin the
+/// shape so a refactor that swaps data structures surfaces here loudly.
+/// </remarks>
+[Trait("Category", "Unit")]
+[Trait("Category", "CodeGeneration")]
+[Trait("Category", "CpuKernelGeneratorOperators")]
+public sealed class CpuKernelGeneratorOperatorTests
+{
+    private readonly CpuKernelGenerator _generator = new();
+
+    #region OrderBy — metadata and key-selector paths
+
+    [Fact]
+    public void OrderBy_DefaultMetadata_AscendingLabelEmitted()
+    {
+        var graph = CreateGraph(OperationType.OrderBy);
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("OrderBy operation (ascending)");
+        _ = code.Should().NotContain("Array.Reverse");
+    }
+
+    [Fact]
+    public void OrderBy_DescendingMetadataFalse_DefaultsToAscending()
+    {
+        var op = new Operation
+        {
+            Id = "sort",
+            Type = OperationType.OrderBy,
+            Metadata = new Dictionary<string, object> { ["Descending"] = false }
+        };
+        var graph = new OperationGraph { Operations = new Collection<Operation> { op } };
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("OrderBy operation (ascending)");
+        _ = code.Should().NotContain("Array.Reverse");
+    }
+
+    [Fact]
+    public void OrderBy_WithKeySelector_DescendingReversesSortedValues()
+    {
+        Expression<Func<int, int>> keySelector = x => -x;
+        var op = new Operation
+        {
+            Id = "sort",
+            Type = OperationType.OrderBy,
+            Metadata = new Dictionary<string, object>
+            {
+                ["Lambda"] = keySelector,
+                ["Descending"] = true
+            }
+        };
+        var graph = new OperationGraph { Operations = new Collection<Operation> { op } };
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("sortKeys");
+        _ = code.Should().Contain("Array.Sort(sortKeys, sortValues)");
+        _ = code.Should().Contain("Array.Reverse(sortValues)");
+    }
+
+    [Fact]
+    public void OrderBy_WithFloatKeySelector_DeclaresFloatKeyArray()
+    {
+        Expression<Func<int, float>> keySelector = x => (float)x * 0.5f;
+        var graph = CreateGraph(OperationType.OrderBy, keySelector);
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("new float[output.Length]");
+    }
+
+    [Theory]
+    [InlineData(typeof(int), "int")]
+    [InlineData(typeof(long), "long")]
+    [InlineData(typeof(float), "float")]
+    [InlineData(typeof(double), "double")]
+    [InlineData(typeof(short), "short")]
+    [InlineData(typeof(byte), "byte")]
+    public void OrderBy_NaturalSort_EmitsTypedSortBuffer(Type elementType, string typeName)
+    {
+        var graph = CreateGraph(OperationType.OrderBy);
+        var metadata = new TypeMetadata
+        {
+            InputType = elementType,
+            ResultType = elementType,
+            IntermediateTypes = new Dictionary<string, Type>(),
+            IsSimdCompatible = true,
+            RequiresUnsafe = false,
+            HasNullableTypes = false
+        };
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain($"new {typeName}[output.Length]");
+        _ = code.Should().Contain("Array.Sort(sortBuffer)");
+    }
+
+    [Fact]
+    public void OrderBy_CopiesInputToOutputBeforeSorting()
+    {
+        // input.CopyTo(output) ensures the algorithm doesn't mutate the caller's buffer.
+        var graph = CreateGraph(OperationType.OrderBy);
+        var metadata = CreateMetadata<double, double>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("input.CopyTo(output);");
+    }
+
+    [Fact]
+    public void OrderBy_DescendingNaturalSort_ReversesBuffer()
+    {
+        var op = new Operation
+        {
+            Id = "sort",
+            Type = OperationType.OrderBy,
+            Metadata = new Dictionary<string, object> { ["Descending"] = true }
+        };
+        var graph = new OperationGraph { Operations = new Collection<Operation> { op } };
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("Array.Sort(sortBuffer)");
+        _ = code.Should().Contain("Array.Reverse(sortBuffer)");
+    }
+
+    [Fact]
+    public void OrderBy_DescendingMetadata_NonBoolValue_TreatedAsAscending()
+    {
+        // Generator uses `descObj is true` — any non-bool value (even truthy)
+        // must not enable descending mode. This is a subtle failure mode.
+        var op = new Operation
+        {
+            Id = "sort",
+            Type = OperationType.OrderBy,
+            Metadata = new Dictionary<string, object> { ["Descending"] = "yes" }
+        };
+        var graph = new OperationGraph { Operations = new Collection<Operation> { op } };
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("ascending");
+        _ = code.Should().NotContain("Array.Reverse");
+    }
+
+    #endregion
+
+    #region GroupBy — aggregation kinds
+
+    [Theory]
+    [InlineData("Sum")]
+    [InlineData("Min")]
+    [InlineData("Max")]
+    [InlineData("Average")]
+    [InlineData("Avg")]
+    public void GroupBy_NonCountAggregation_EmitsAccumulatorTuple(string aggregation)
+    {
+        var op = new Operation
+        {
+            Id = "groupBy",
+            Type = OperationType.GroupBy,
+            Metadata = new Dictionary<string, object> { ["Aggregation"] = aggregation }
+        };
+        var graph = new OperationGraph { Operations = new Collection<Operation> { op } };
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        // Non-count aggregations produce (accumulator, count) tuples per key.
+        _ = code.Should().Contain("(int Acc, int Count)");
+        _ = code.Should().Contain("current.Count + 1");
+    }
+
+    [Fact]
+    public void GroupBy_CountAggregation_EmitsIntegerCountDictionary()
+    {
+        var op = new Operation
+        {
+            Id = "groupBy",
+            Type = OperationType.GroupBy,
+            Metadata = new Dictionary<string, object> { ["Aggregation"] = "Count" }
+        };
+        var graph = new OperationGraph { Operations = new Collection<Operation> { op } };
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("Dictionary<int, int>");
+        _ = code.Should().Contain("counts[key] = counts.TryGetValue(key, out var c) ? c + 1 : 1;");
+    }
+
+    [Fact]
+    public void GroupBy_UnknownAggregation_FallsBackToCount()
+    {
+        // Any unrecognized aggregation key is treated as Count (default branch).
+        var op = new Operation
+        {
+            Id = "groupBy",
+            Type = OperationType.GroupBy,
+            Metadata = new Dictionary<string, object> { ["Aggregation"] = "NonExistent" }
+        };
+        var graph = new OperationGraph { Operations = new Collection<Operation> { op } };
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("GroupBy operation with NonExistent aggregation");
+        _ = code.Should().Contain("counts.TryGetValue");
+    }
+
+    [Fact]
+    public void GroupBy_NoMetadata_DefaultsToCountAggregation()
+    {
+        var graph = CreateGraph(OperationType.GroupBy);
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("Count aggregation");
+        _ = code.Should().Contain("counts");
+    }
+
+    [Fact]
+    public void GroupBy_SumAggregation_WritesAccumulatorToOutput()
+    {
+        var op = new Operation
+        {
+            Id = "groupBy",
+            Type = OperationType.GroupBy,
+            Metadata = new Dictionary<string, object> { ["Aggregation"] = "Sum" }
+        };
+        var graph = new OperationGraph { Operations = new Collection<Operation> { op } };
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("output[groupIdx++] = (int)kv.Value.Acc;");
+    }
+
+    [Fact]
+    public void GroupBy_AverageAggregation_CastsAccumulatorToDoubleForDivision()
+    {
+        var op = new Operation
+        {
+            Id = "groupBy",
+            Type = OperationType.GroupBy,
+            Metadata = new Dictionary<string, object> { ["Aggregation"] = "Avg" }
+        };
+        var graph = new OperationGraph { Operations = new Collection<Operation> { op } };
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("(double)kv.Value.Count");
+    }
+
+    [Fact]
+    public void GroupBy_MinAggregation_EmitsLessThanComparison()
+    {
+        var op = new Operation
+        {
+            Id = "groupBy",
+            Type = OperationType.GroupBy,
+            Metadata = new Dictionary<string, object> { ["Aggregation"] = "Min" }
+        };
+        var graph = new OperationGraph { Operations = new Collection<Operation> { op } };
+        var metadata = CreateMetadata<float, float>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("value < current.Acc ? value : current.Acc");
+    }
+
+    [Fact]
+    public void GroupBy_MaxAggregation_EmitsGreaterThanComparison()
+    {
+        var op = new Operation
+        {
+            Id = "groupBy",
+            Type = OperationType.GroupBy,
+            Metadata = new Dictionary<string, object> { ["Aggregation"] = "Max" }
+        };
+        var graph = new OperationGraph { Operations = new Collection<Operation> { op } };
+        var metadata = CreateMetadata<float, float>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("value > current.Acc ? value : current.Acc");
+    }
+
+    [Fact]
+    public void GroupBy_HonorsOutputCapacity_EmitsBoundsCheck()
+    {
+        // Output write must be guarded so a small output span doesn't overflow.
+        var graph = CreateGraph(OperationType.GroupBy);
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("if (groupIdx >= output.Length) break;");
+    }
+
+    [Fact]
+    public void GroupBy_NoKeySelector_UsesElementAsKey()
+    {
+        var graph = CreateGraph(OperationType.GroupBy);
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        // Without a key selector, input[i] is the key.
+        _ = code.Should().Contain("var key = input[i];");
+    }
+
+    [Fact]
+    public void GroupBy_WithDifferentKeyType_EmitsCorrectDictionaryGenericArg()
+    {
+        Expression<Func<int, long>> keySelector = x => (long)x;
+        var graph = CreateGraph(OperationType.GroupBy, keySelector);
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("Dictionary<long,");
+    }
+
+    [Theory]
+    [InlineData(typeof(int), typeof(int), "int")]
+    [InlineData(typeof(long), typeof(long), "long")]
+    [InlineData(typeof(float), typeof(float), "float")]
+    [InlineData(typeof(double), typeof(double), "double")]
+    public void GroupBy_Sum_AggregatorTypeMatchesOutputType(
+        Type inputType, Type outputType, string outputTypeName)
+    {
+        var op = new Operation
+        {
+            Id = "groupBy",
+            Type = OperationType.GroupBy,
+            Metadata = new Dictionary<string, object> { ["Aggregation"] = "Sum" }
+        };
+        var graph = new OperationGraph { Operations = new Collection<Operation> { op } };
+        var metadata = new TypeMetadata
+        {
+            InputType = inputType,
+            ResultType = outputType,
+            IntermediateTypes = new Dictionary<string, Type>(),
+            IsSimdCompatible = true,
+            RequiresUnsafe = false,
+            HasNullableTypes = false
+        };
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain($"({outputTypeName} Acc, int Count)");
+        _ = code.Should().Contain($"({outputTypeName})input[i]");
+    }
+
+    #endregion
+
+    #region Join — hash-based dedup
+
+    [Fact]
+    public void Join_EmitsHashSetAndWriteIndex()
+    {
+        var graph = CreateGraph(OperationType.Join);
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("new HashSet<int>()");
+        _ = code.Should().Contain("int writeIdx = 0;");
+        _ = code.Should().Contain("if (seen.Add(key))");
+    }
+
+    [Fact]
+    public void Join_HonorsOutputCapacity()
+    {
+        // Prevents overflow when output is smaller than distinct-key cardinality.
+        var graph = CreateGraph(OperationType.Join);
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("if (writeIdx < output.Length)");
+    }
+
+    [Fact]
+    public void Join_WithKeySelector_UsesLambdaKeyExtraction()
+    {
+        Expression<Func<int, int>> keySelector = x => x / 10;
+        var graph = CreateGraph(OperationType.Join, keySelector);
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("/ 10");
+    }
+
+    [Fact]
+    public void Join_WithStringKeySelector_EmitsStringHashSet()
+    {
+        Expression<Func<int, string>> keySelector = x => x.ToString();
+        var graph = CreateGraph(OperationType.Join, keySelector);
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("new HashSet<string>()");
+    }
+
+    [Fact]
+    public void Join_NoKeySelector_KeyIsInputElement()
+    {
+        var graph = CreateGraph(OperationType.Join);
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("var key = input[i];");
+    }
+
+    [Fact]
+    public void Join_WritesOriginalInputElementNotKey()
+    {
+        // The dedup semantic: key is used for Add(); original element is written.
+        Expression<Func<int, long>> keySelector = x => (long)x;
+        var graph = CreateGraph(OperationType.Join, keySelector);
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("output[writeIdx++] = input[i];");
+    }
+
+    [Theory]
+    [InlineData(typeof(int), "int")]
+    [InlineData(typeof(long), "long")]
+    [InlineData(typeof(float), "float")]
+    [InlineData(typeof(double), "double")]
+    [InlineData(typeof(short), "short")]
+    public void Join_TypePermutations_EmitCorrectHashSetType(Type elementType, string typeName)
+    {
+        var graph = CreateGraph(OperationType.Join);
+        var metadata = new TypeMetadata
+        {
+            InputType = elementType,
+            ResultType = elementType,
+            IntermediateTypes = new Dictionary<string, Type>(),
+            IsSimdCompatible = true,
+            RequiresUnsafe = false,
+            HasNullableTypes = false
+        };
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain($"new HashSet<{typeName}>()");
+    }
+
+    #endregion
+
+    #region Multi-op graphs and fusion paths
+
+    [Fact]
+    public void MapMapFusion_AppliesBothLambdasInSingleLoop()
+    {
+        Expression<Func<int, int>> first = x => x + 1;
+        Expression<Func<int, int>> second = x => x * 2;
+        var op1 = new Operation
+        {
+            Id = "op1",
+            Type = OperationType.Map,
+            Metadata = new Dictionary<string, object> { ["Lambda"] = first }
+        };
+        var op2 = new Operation
+        {
+            Id = "op2",
+            Type = OperationType.Map,
+            Metadata = new Dictionary<string, object> { ["Lambda"] = second }
+        };
+        var graph = new OperationGraph { Operations = new Collection<Operation> { op1, op2 } };
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("Fused operations");
+        _ = code.Should().Contain("+ 1");
+        _ = code.Should().Contain("* 2");
+    }
+
+    [Fact]
+    public void MapFilterFusion_ProducesFusedSelectWhereBlock()
+    {
+        Expression<Func<int, int>> map = x => x + 10;
+        Expression<Func<int, bool>> filter = x => x > 15;
+        var op1 = new Operation
+        {
+            Id = "op1",
+            Type = OperationType.Map,
+            Metadata = new Dictionary<string, object> { ["Lambda"] = map }
+        };
+        var op2 = new Operation
+        {
+            Id = "op2",
+            Type = OperationType.Filter,
+            Metadata = new Dictionary<string, object> { ["Lambda"] = filter }
+        };
+        var graph = new OperationGraph { Operations = new Collection<Operation> { op1, op2 } };
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("Fused Select + Where");
+        _ = code.Should().Contain("var transformed =");
+        _ = code.Should().Contain("var mask =");
+    }
+
+    [Fact]
+    public void FilterMapFusion_ProducesFusedWhereSelectBlock()
+    {
+        Expression<Func<int, bool>> filter = x => x > 0;
+        Expression<Func<int, int>> map = x => x * 3;
+        var op1 = new Operation
+        {
+            Id = "op1",
+            Type = OperationType.Filter,
+            Metadata = new Dictionary<string, object> { ["Lambda"] = filter }
+        };
+        var op2 = new Operation
+        {
+            Id = "op2",
+            Type = OperationType.Map,
+            Metadata = new Dictionary<string, object> { ["Lambda"] = map }
+        };
+        var graph = new OperationGraph { Operations = new Collection<Operation> { op1, op2 } };
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("Fused Where + Select");
+    }
+
+    [Fact]
+    public void NonFusableOps_SortThenMap_GeneratesSeparateBlocks()
+    {
+        Expression<Func<int, int>> map = x => x + 1;
+        var op1 = new Operation
+        {
+            Id = "op1",
+            Type = OperationType.OrderBy,
+            Metadata = new Dictionary<string, object>()
+        };
+        var op2 = new Operation
+        {
+            Id = "op2",
+            Type = OperationType.Map,
+            Metadata = new Dictionary<string, object> { ["Lambda"] = map }
+        };
+        var graph = new OperationGraph { Operations = new Collection<Operation> { op1, op2 } };
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        // OrderBy does not fuse — two distinct operation comments.
+        _ = code.Should().Contain("OrderBy operation");
+        _ = code.Should().Contain("Map operation");
+    }
+
+    [Fact]
+    public void ScanThenMap_NonFusable_ProducesIndependentBlocks()
+    {
+        Expression<Func<int, int>> map = x => x + 2;
+        var op1 = new Operation
+        {
+            Id = "op1",
+            Type = OperationType.Scan,
+            Metadata = new Dictionary<string, object>()
+        };
+        var op2 = new Operation
+        {
+            Id = "op2",
+            Type = OperationType.Map,
+            Metadata = new Dictionary<string, object> { ["Lambda"] = map }
+        };
+        var graph = new OperationGraph { Operations = new Collection<Operation> { op1, op2 } };
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("Scan operation");
+        _ = code.Should().Contain("Map operation");
+    }
+
+    #endregion
+
+    #region Error paths specific to operator dispatch
+
+    [Fact]
+    public void JoinWithoutKeySelectorAndOutputCapacity_EmitsBoundsCheck()
+    {
+        // Regression: generator must always guard output writes in Join.
+        var graph = CreateGraph(OperationType.Join);
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().Contain("writeIdx < output.Length");
+        _ = code.Should().NotContain("passing through"); // legacy placeholder string
+    }
+
+    [Fact]
+    public void OrderBy_OutputContainsNoLegacyPassthrough()
+    {
+        // OrderBy was previously a placeholder — guard against regression.
+        var graph = CreateGraph(OperationType.OrderBy);
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().NotContain("TODO");
+        _ = code.Should().NotContain("passing through");
+        _ = code.Should().NotContain("not yet implemented");
+    }
+
+    [Fact]
+    public void GroupBy_OutputContainsNoLegacyPassthrough()
+    {
+        var graph = CreateGraph(OperationType.GroupBy);
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().NotContain("TODO");
+        _ = code.Should().NotContain("passing through");
+        _ = code.Should().NotContain("not yet implemented");
+    }
+
+    [Fact]
+    public void Join_OutputContainsNoLegacyPassthrough()
+    {
+        var graph = CreateGraph(OperationType.Join);
+        var metadata = CreateMetadata<int, int>();
+
+        var code = _generator.GenerateKernel(graph, metadata);
+
+        _ = code.Should().NotContain("TODO");
+        _ = code.Should().NotContain("passing through");
+        _ = code.Should().NotContain("not yet implemented");
+    }
+
+    #endregion
+
+    #region Concurrency surface — repeated calls do not corrupt state
+
+    [Fact]
+    public void Generator_AlternatingOperatorCalls_KeepOutputsDistinct()
+    {
+        // Simulates a pipeline compiling many kernels through one generator.
+        var mapGraph = CreateGraph(OperationType.Map, (Expression<Func<int, int>>)(x => x + 1));
+        var reduceGraph = CreateGraph(OperationType.Reduce, (Expression<Func<int, int>>)(x => x));
+        var metadata = CreateMetadata<int, int>();
+
+        var mapCode = _generator.GenerateKernel(mapGraph, metadata);
+        var reduceCode = _generator.GenerateKernel(reduceGraph, metadata);
+        var mapCodeAgain = _generator.GenerateKernel(mapGraph, metadata);
+
+        _ = mapCode.Should().Contain("Map operation");
+        _ = reduceCode.Should().Contain("Reduce operation");
+        _ = mapCode.Should().NotContain("Reduce operation");
+        _ = reduceCode.Should().NotContain("Map operation");
+        _ = mapCodeAgain.Should().Be(mapCode);
+    }
+
+    [Fact]
+    public void Generator_ProducesSameOutputAcrossTwoInstances()
+    {
+        var graph = CreateGraph(OperationType.Map, (Expression<Func<int, int>>)(x => x + 1));
+        var metadata = CreateMetadata<int, int>();
+
+        var first = new CpuKernelGenerator().GenerateKernel(graph, metadata);
+        var second = new CpuKernelGenerator().GenerateKernel(graph, metadata);
+
+        _ = second.Should().Be(first);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static OperationGraph CreateGraph(OperationType type, LambdaExpression? lambda = null)
+    {
+        var metadata = new Dictionary<string, object>();
+        if (lambda != null)
+        {
+            metadata["Lambda"] = lambda;
+        }
+
+        var op = new Operation
+        {
+            Id = "op",
+            Type = type,
+            Metadata = metadata
+        };
+
+        return new OperationGraph { Operations = new Collection<Operation> { op } };
+    }
+
+    private static TypeMetadata CreateMetadata<TInput, TOutput>()
+    {
+        return new TypeMetadata
+        {
+            InputType = typeof(TInput),
+            ResultType = typeof(TOutput),
+            IntermediateTypes = new Dictionary<string, Type>(),
+            IsSimdCompatible = true,
+            RequiresUnsafe = false,
+            HasNullableTypes = false
+        };
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

Adds 110 new unit tests across two files targeting `CpuKernelGenerator` — the 1701-LOC SIMD CPU codegen critical to v1.0.0 GA. Previously only integration-tested plus 60 baseline unit tests; this PR extends to **170 total** across structural, edge-case, and error paths.

- **CpuKernelGeneratorEdgeCasesTests.cs** (~56 test cases): Scan operator (previously untested), type permutations across every supported primitive, complex/non-primitive types, structural emission guarantees (vector constants, horizontal sum, constant suffixes), argument validation.
- **CpuKernelGeneratorOperatorTests.cs** (~54 test cases): OrderBy / GroupBy / Join edge cases beyond Phase 8, metadata-driven behavior (Descending, Aggregation), fusion paths, regression guards against legacy placeholder strings.

No changes to `CpuKernelGenerator.cs` itself — no bugs were caught by the new tests. One codegen quirk (non-primitive types render via `Type.Name` producing `Decimal` instead of `decimal`) was surfaced but is valid C#, so the test asserts the existing behavior rather than forcing a fix.

## Changes

- `tests/Unit/DotCompute.Linq.Tests/CodeGeneration/CpuKernelGeneratorEdgeCasesTests.cs` (new, 674 LOC, 36 methods)
- `tests/Unit/DotCompute.Linq.Tests/CodeGeneration/CpuKernelGeneratorOperatorTests.cs` (new, 754 LOC, 38 methods)

Follows the pattern established by `JoinGroupByOrderByTests.cs`: `[Fact]`/`[Theory]` with xUnit, FluentAssertions, `[Trait("Category", "Unit")]`.

## Test plan

- [x] `dotnet build DotCompute.sln --configuration Release` — 0 warnings, 0 errors
- [x] `dotnet test --filter "FullyQualifiedName~CpuKernelGenerator"` — 170/170 passing (60 baseline + 110 new)
- [x] All new tests target behavior not covered by baseline tests
- [x] No modifications to `CpuKernelGenerator.cs`
- [x] No new NuGet packages added

## Coverage estimate

Approximate coverage delta for `CpuKernelGenerator.cs`:
- **Before**: ~45% line coverage (estimated — baseline 60 tests exercise Map/Filter/Reduce/fusion happy paths + some validation)
- **After**: ~80% line coverage (estimated — adds Scan, OrderBy, GroupBy all aggregation kinds, Join, argument validation, type permutations, structural branches)

Uncovered paths remaining: `GenerateParallelReduction` (emits `Partitioner`-based code; only reached with large workload heuristic which is hardcoded), some `ExpressionToCode` fallbacks for unsupported node types, and `OptimizeForType`/`GenerateScalarFallback` (dead or rarely invoked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)