### PR TITLE
chore: adopt System.Threading.Lock over object _lock

### DIFF
--- a/src/Backends/DotCompute.Backends.CPU/RingKernels/CpuMessageQueue.cs
+++ b/src/Backends/DotCompute.Backends.CPU/RingKernels/CpuMessageQueue.cs
@@ -22,7 +22,7 @@ public sealed class CpuMessageQueue<T> : IMessageQueue<T> where T : unmanaged
     private readonly int _capacity;
     private readonly ILogger<CpuMessageQueue<T>> _logger;
     private readonly BlockingCollection<KernelMessage<T>> _queue;
-    private readonly object _lock = new();
+    private readonly Lock _lock = new();
 
     // Statistics tracking
     private readonly Stopwatch _uptimeStopwatch = Stopwatch.StartNew();

--- a/src/Backends/DotCompute.Backends.CPU/RingKernels/CpuOutputBridge.cs
+++ b/src/Backends/DotCompute.Backends.CPU/RingKernels/CpuOutputBridge.cs
@@ -40,7 +40,7 @@ internal sealed class CpuOutputBridge<T> : IDisposable where T : IRingKernelMess
     private readonly GCHandle _pinnedBufferHandle;
     private readonly T[] _buffer;
     private readonly int _bufferCapacity;
-    private readonly object _syncLock = new();
+    private readonly Lock _syncLock = new();
 
     private int _bufferHead;
     private int _bufferCount;

--- a/src/Backends/DotCompute.Backends.CUDA/Adapters/CudaMemoryManagementAdapter.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/Adapters/CudaMemoryManagementAdapter.cs
@@ -20,7 +20,7 @@ public sealed class CudaMemoryManagementAdapter : IMemoryManagementPort, IDispos
     private readonly CudaContext _context;
     private readonly ILogger<CudaMemoryManagementAdapter> _logger;
     private readonly MemoryCapabilities _capabilities;
-    private readonly object _statsLock = new();
+    private readonly Lock _statsLock = new();
     private long _allocatedBytes;
     private long _peakAllocatedBytes;
     private int _allocationCount;

--- a/src/Backends/DotCompute.Backends.CUDA/Barriers/CudaBarrierHandle.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/Barriers/CudaBarrierHandle.cs
@@ -46,7 +46,7 @@ public sealed class CudaBarrierHandle : IBarrierHandle
 
     // For grid barriers, we need device memory to track state
     private IntPtr _deviceBarrierPtr;
-    private readonly object _lock = new();
+    private readonly Lock _lock = new();
 
     /// <summary>
     /// Initializes a new CUDA barrier handle.

--- a/src/Backends/DotCompute.Backends.CUDA/Barriers/CudaCrossGpuBarrier.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/Barriers/CudaCrossGpuBarrier.cs
@@ -44,7 +44,7 @@ public sealed class CudaCrossGpuBarrier : ICrossGpuBarrier
     private int _arrivedCount;
     private readonly HlcTimestamp?[] _arrivalTimestamps;
     private readonly Stopwatch[] _arrivalStopwatches;
-    private readonly object _stateLock = new();
+    private readonly Lock _stateLock = new();
     private bool _disposed;
 
     // P2P memory pointers (if P2P mode)

--- a/src/Backends/DotCompute.Backends.CUDA/Barriers/CudaSystemBarrier.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/Barriers/CudaSystemBarrier.cs
@@ -86,7 +86,7 @@ public sealed partial class CudaSystemBarrier : IBarrierHandle
     private readonly List<CudaContext> _contexts;
     private readonly List<int> _deviceIds;
     private readonly TimeSpan _defaultTimeout;
-    private readonly object _syncLock = new();
+    private readonly Lock _syncLock = new();
     private int _threadsWaiting;
     private bool _disposed;
 

--- a/src/Backends/DotCompute.Backends.CUDA/Barriers/MultiGpuSynchronizer.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/Barriers/MultiGpuSynchronizer.cs
@@ -102,7 +102,7 @@ public sealed partial class MultiGpuSynchronizer : IDisposable
     private readonly ConcurrentDictionary<int, BarrierState> _barrierStates;
     private readonly IntPtr _hostSignalMemory; // Pinned host memory for cross-GPU signaling
     private readonly bool _usedCudaMemory; // Flag to track if CUDA memory or fallback was used
-    private readonly object _syncLock = new();
+    private readonly Lock _syncLock = new();
     private bool _disposed;
 
     /// <summary>

--- a/src/Backends/DotCompute.Backends.CUDA/CudaAccelerator.Health.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/CudaAccelerator.Health.cs
@@ -17,7 +17,7 @@ namespace DotCompute.Backends.CUDA
     {
         private NvmlWrapper? _nvmlWrapper;
         private bool _nvmlInitialized;
-        private readonly object _nvmlLock = new();
+        private readonly Lock _nvmlLock = new();
 
         /// <summary>
         /// Gets a comprehensive health snapshot of the CUDA device.

--- a/src/Backends/DotCompute.Backends.CUDA/RingKernels/CudaRingKernelRuntime.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/RingKernels/CudaRingKernelRuntime.cs
@@ -41,7 +41,7 @@ public sealed partial class CudaRingKernelRuntime : IRingKernelRuntime
     private readonly RingKernelFaultRecoveryOptions _faultRecoveryOptions;
     private readonly ConcurrentDictionary<string, KernelState> _kernels = new();
     private readonly ConcurrentDictionary<string, Assembly> _registeredAssemblies = new();
-    private readonly object _contextLock = new();
+    private readonly Lock _contextLock = new();
     private IntPtr _sharedContext;
     private int _sharedDevice = -1;  // Device ID for primary context release
     private int _contextRefCount;

--- a/src/Backends/DotCompute.Backends.CUDA/Scheduling/CudaHierarchicalTaskQueue.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/Scheduling/CudaHierarchicalTaskQueue.cs
@@ -47,7 +47,7 @@ public sealed class CudaHierarchicalTaskQueue : IHierarchicalTaskQueue
     private long _totalEnqueued;
     private long _totalDequeued;
     private long _totalStolen;
-    private readonly object _statsLock = new();
+    private readonly Lock _statsLock = new();
 
     // Wait time tracking per priority
     private readonly List<TimeSpan>[] _waitTimesByPriority;

--- a/src/Backends/DotCompute.Backends.Metal/Adapters/MetalMemoryManagementAdapter.cs
+++ b/src/Backends/DotCompute.Backends.Metal/Adapters/MetalMemoryManagementAdapter.cs
@@ -19,7 +19,7 @@ public sealed class MetalMemoryManagementAdapter : IMemoryManagementPort, IDispo
 {
     private readonly ILogger<MetalMemoryManagementAdapter> _logger;
     private readonly MemoryCapabilities _capabilities;
-    private readonly object _statsLock = new();
+    private readonly Lock _statsLock = new();
     private long _allocatedBytes;
     private long _peakAllocatedBytes;
     private int _allocationCount;

--- a/src/Backends/DotCompute.Backends.Metal/Barriers/MetalBarrierHandle.cs
+++ b/src/Backends/DotCompute.Backends.Metal/Barriers/MetalBarrierHandle.cs
@@ -38,7 +38,7 @@ internal sealed class MetalBarrierHandle : IBarrierHandle
     private bool _isActive;
     private int _syncCount;
     private bool _disposed;
-    private readonly object _lock = new();
+    private readonly Lock _lock = new();
 
     /// <summary>
     /// Initializes a new Metal barrier handle.

--- a/src/Backends/DotCompute.Backends.Metal/Memory/MetalUnifiedMemoryOptimizer.cs
+++ b/src/Backends/DotCompute.Backends.Metal/Memory/MetalUnifiedMemoryOptimizer.cs
@@ -20,7 +20,7 @@ public sealed class MetalUnifiedMemoryOptimizer : IDisposable
     private bool _disposed;
     private long _totalZeroCopyOperations;
     private long _totalBytesTransferred;
-    private readonly object _statsLock = new();
+    private readonly Lock _statsLock = new();
 
     /// <summary>
     /// Gets whether the system is running on Apple Silicon with unified memory.

--- a/src/Core/DotCompute.Abstractions/Messaging/ICorrelationManager.cs
+++ b/src/Core/DotCompute.Abstractions/Messaging/ICorrelationManager.cs
@@ -141,7 +141,7 @@ public sealed class CorrelationContext<TResponse> : ICorrelationContextBase
     private readonly Timer? _timeoutTimer;
     private bool _completed;
     private bool _disposed;
-    private readonly object _lock = new();
+    private readonly Lock _lock = new();
 
     /// <summary>
     /// Gets the correlation ID for this request.

--- a/src/Core/DotCompute.Core/FaultTolerance/ChaosEngine.cs
+++ b/src/Core/DotCompute.Core/FaultTolerance/ChaosEngine.cs
@@ -23,7 +23,7 @@ public sealed partial class ChaosEngine : IChaosEngine
     private readonly ConcurrentQueue<FaultInjectionRecord> _history = new();
     private readonly ConcurrentDictionary<FaultType, int> _countByType = new();
     private readonly ConcurrentDictionary<string, int> _countByComponent = new();
-    private readonly object _lock = new();
+    private readonly Lock _lock = new();
     private DateTimeOffset _sessionStarted;
     private int _totalOpportunities;
     private int _faultsInjected;

--- a/src/Core/DotCompute.Core/FaultTolerance/CheckpointManager.cs
+++ b/src/Core/DotCompute.Core/FaultTolerance/CheckpointManager.cs
@@ -21,7 +21,7 @@ public sealed partial class CheckpointManager : ICheckpointManager
     private readonly CheckpointOptions _options;
     private readonly ILogger<CheckpointManager> _logger;
     private readonly Dictionary<string, DateTimeOffset> _lastCheckpointTimes = new();
-    private readonly object _lock = new();
+    private readonly Lock _lock = new();
     private bool _disposed;
 
     // Event IDs: 9800-9899 for CheckpointManager

--- a/src/Core/DotCompute.Core/FaultTolerance/InMemoryCheckpointStorage.cs
+++ b/src/Core/DotCompute.Core/FaultTolerance/InMemoryCheckpointStorage.cs
@@ -19,7 +19,7 @@ public sealed partial class InMemoryCheckpointStorage : ICheckpointStorage
     private readonly ConcurrentDictionary<Guid, StoredCheckpoint> _checkpoints = new();
     private readonly ConcurrentDictionary<string, List<Guid>> _componentIndex = new();
     private readonly ILogger<InMemoryCheckpointStorage> _logger;
-    private readonly object _lock = new();
+    private readonly Lock _lock = new();
     private bool _disposed;
 
     // Event IDs: 9700-9799 for InMemoryCheckpointStorage

--- a/src/Core/DotCompute.Core/Messaging/DeadLetterQueue.cs
+++ b/src/Core/DotCompute.Core/Messaging/DeadLetterQueue.cs
@@ -19,7 +19,7 @@ public sealed partial class DeadLetterQueue : IDeadLetterQueue
     private readonly DeadLetterQueueOptions _options;
     private readonly ILogger<DeadLetterQueue> _logger;
     private readonly Timer? _cleanupTimer;
-    private readonly object _lock = new();
+    private readonly Lock _lock = new();
     private long _totalDeadLettered;
     private bool _disposed;
 

--- a/src/Core/DotCompute.Core/Messaging/MessageAggregator.cs
+++ b/src/Core/DotCompute.Core/Messaging/MessageAggregator.cs
@@ -23,7 +23,7 @@ public sealed partial class MessageAggregator<TResponse, TResult> : IMessageAggr
     private readonly Dictionary<Guid, Exception> _failures = new();
     private readonly CancellationTokenRegistration _cancellationRegistration;
     private readonly Timer? _timeoutTimer;
-    private readonly object _lock = new();
+    private readonly Lock _lock = new();
     private bool _completed;
     private bool _disposed;
 

--- a/src/Core/DotCompute.Core/Messaging/MessageBatcher.cs
+++ b/src/Core/DotCompute.Core/Messaging/MessageBatcher.cs
@@ -14,7 +14,7 @@ public sealed partial class MessageBatcher : IMessageBatcher
 {
     private readonly BatchingOptions _options;
     private readonly ILogger<MessageBatcher> _logger;
-    private readonly object _lock = new();
+    private readonly Lock _lock = new();
     private readonly List<BatchedMessageEntry> _entries = new();
     private readonly Timer? _flushTimer;
     private DateTimeOffset _batchCreatedAt;

--- a/src/Core/DotCompute.Core/RingKernels/Profiling/PerformanceProfiler.cs
+++ b/src/Core/DotCompute.Core/RingKernels/Profiling/PerformanceProfiler.cs
@@ -254,7 +254,7 @@ internal sealed class KernelProfilingSession : IDisposable
     private readonly Action<string, PerformanceAnomaly> _anomalyCallback;
     private readonly LatencyHistogram _latencyHistogram = new();
     private readonly List<ThroughputSample> _throughputSamples = new();
-    private readonly object _throughputLock = new();
+    private readonly Lock _throughputLock = new();
     private readonly List<PerformanceAnomaly> _anomalies = new();
     private readonly DateTimeOffset _startTime = DateTimeOffset.UtcNow;
 
@@ -271,7 +271,7 @@ internal sealed class KernelProfilingSession : IDisposable
     private long _allocationCount;
     private long _deallocationCount;
     private readonly Queue<DateTimeOffset> _recentAllocations = new();
-    private readonly object _allocationLock = new();
+    private readonly Lock _allocationLock = new();
     private double _peakThroughput;
     private double _lastThroughput;
     private PerformanceBaseline? _baseline;

--- a/src/Core/DotCompute.Core/Security/ResourceQuotaManager.cs
+++ b/src/Core/DotCompute.Core/Security/ResourceQuotaManager.cs
@@ -354,7 +354,7 @@ public sealed class ResourceQuotaManager : IResourceQuotaManager, IDisposable
         private int _activeKernels;
         private long _peakMemoryBytes;
         private long _totalExecutions;
-        private readonly object _lock = new();
+        private readonly Lock _lock = new();
 
         public ISecurityPrincipal Principal { get; }
         public ResourceLimits Limits { get; set; }

--- a/src/Core/DotCompute.Memory/MemoryStatistics.cs
+++ b/src/Core/DotCompute.Memory/MemoryStatistics.cs
@@ -32,7 +32,7 @@ public sealed class MemoryStatistics
     private double _totalDeallocationTimeMs;
     private double _totalCopyTimeMs;
     private long _copyOperations;
-    private readonly object _syncLock = new();
+    private readonly Lock _syncLock = new();
 
     /// <summary>
     /// Gets the number of bytes currently allocated and not yet freed.

--- a/src/Extensions/DotCompute.Linq/CodeGeneration/BackendSelector.cs
+++ b/src/Extensions/DotCompute.Linq/CodeGeneration/BackendSelector.cs
@@ -20,7 +20,7 @@ public sealed class BackendSelector
 {
     private readonly ILogger<BackendSelector> _logger;
     private readonly AvailableBackends _availableBackends;
-    private static readonly object _detectionLock = new();
+    private static readonly Lock _detectionLock = new();
     private static AvailableBackends? _cachedBackends;
 
     // Performance thresholds (tuned based on benchmarks)

--- a/src/Extensions/DotCompute.Linq/CodeGeneration/CompilationPipeline.cs
+++ b/src/Extensions/DotCompute.Linq/CodeGeneration/CompilationPipeline.cs
@@ -64,7 +64,7 @@ public sealed class CompilationPipeline : IDisposable
     private long _fallbackCount;
 
     // Compilation synchronization to prevent duplicate compilations
-    private readonly object _compilationLock = new();
+    private readonly Lock _compilationLock = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CompilationPipeline"/> class.

--- a/src/Extensions/DotCompute.Linq/Optimization/AdaptiveOptimizer.cs
+++ b/src/Extensions/DotCompute.Linq/Optimization/AdaptiveOptimizer.cs
@@ -28,7 +28,7 @@ public sealed class AdaptiveOptimizer : IAdaptiveOptimizer
     private readonly ILogger<AdaptiveOptimizer> _logger;
     private readonly ConcurrentDictionary<string, PerformanceMetrics> _performanceHistory = new();
     private readonly ConcurrentDictionary<string, List<OptimizationResult>> _strategyResults = new();
-    private readonly object _lockObject = new();
+    private readonly Lock _lockObject = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AdaptiveOptimizer"/> class.

--- a/src/Extensions/DotCompute.Linq/Optimization/PerformanceProfiler.cs
+++ b/src/Extensions/DotCompute.Linq/Optimization/PerformanceProfiler.cs
@@ -28,7 +28,7 @@ public sealed class PerformanceProfiler : IPerformanceProfiler
     private readonly ILogger<PerformanceProfiler> _logger;
     private readonly ConcurrentDictionary<string, List<ExecutionRecord>> _executionHistory = new();
     private readonly ConcurrentDictionary<string, double> _averageExecutionTimes = new();
-    private readonly object _lockObject = new();
+    private readonly Lock _lockObject = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PerformanceProfiler"/> class.

--- a/src/Extensions/DotCompute.Linq/Reactive/BackpressureManager.cs
+++ b/src/Extensions/DotCompute.Linq/Reactive/BackpressureManager.cs
@@ -34,7 +34,7 @@ public sealed class BackpressureManager : IBackpressureManager, IDisposable
 
     // Sampling state
     private object? _sampledItem;
-    private readonly object _sampleLock = new();
+    private readonly Lock _sampleLock = new();
 
     // Statistics
     private long _totalItemsProcessed;

--- a/src/Extensions/DotCompute.Linq/Reactive/BatchProcessor.cs
+++ b/src/Extensions/DotCompute.Linq/Reactive/BatchProcessor.cs
@@ -29,7 +29,7 @@ public sealed class BatchProcessor : IBatchProcessor, IDisposable
 
     // Adaptive batching state
     private int _currentOptimalSize = 100;
-    private readonly object _lock = new();
+    private readonly Lock _lock = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="BatchProcessor"/> class.

--- a/src/Runtime/DotCompute.Runtime/Services/Statistics/Compilation/KernelCompilerStatistics.cs
+++ b/src/Runtime/DotCompute.Runtime/Services/Statistics/Compilation/KernelCompilerStatistics.cs
@@ -12,7 +12,7 @@ public sealed class KernelCompilerStatistics
     private long _successfulCompilations;
     private long _cacheHits;
     private double _totalCompilationTimeMs;
-    private readonly object _syncLock = new();
+    private readonly Lock _syncLock = new();
     /// <summary>
     /// Performs record compilation.
     /// </summary>

--- a/src/Runtime/DotCompute.Runtime/Services/Statistics/MemoryStatistics.cs
+++ b/src/Runtime/DotCompute.Runtime/Services/Statistics/MemoryStatistics.cs
@@ -16,7 +16,7 @@ public sealed class MemoryStatistics
     private long _poolMisses;
     private double _totalAllocationTimeMs;
     private double _totalCopyTimeMs;
-    private readonly object _syncLock = new();
+    private readonly Lock _syncLock = new();
     /// <summary>
     /// Gets or sets the currently allocated bytes.
     /// </summary>


### PR DESCRIPTION
## Summary
- Replaces 32 `private readonly object _lock = new()` lock-target fields with `System.Threading.Lock` (C# 13 / .NET 9+) across 31 production source files in `src/`.
- `lock (x) { … }` blocks require no change — the compiler's special-case handling of `lock` on `System.Threading.Lock` calls `EnterScope()` directly.
- One field deliberately kept as `object`: `_blockLock` in `BackpressureManager.cs` (used as a condition variable with `Monitor.Wait` / `Monitor.PulseAll`, which `Lock` cannot support by design — CS9216).

## Why
- **Type safety**: attempting to `lock` on something that isn't a `Lock` is now a compile error.
- **Better analyzer support**: CS9216 catches monitor/lock misuse (we hit this on `_blockLock` during adoption — correctly pointing at the condition-variable use).
- **Modern idiom**: `Lock` is the recommended sync primitive in .NET 9+. Most of the DotCompute codebase already uses it — this PR closes the gap on the last 30-odd holdouts.

## Intentionally-kept `object _lock` sites
| File | Field | Rationale |
|---|---|---|
| `src/Extensions/DotCompute.Linq/Reactive/BackpressureManager.cs` | `_blockLock` | Condition variable via `Monitor.Wait(_blockLock, …)` + `Monitor.PulseAll(_blockLock)`. `System.Threading.Lock` is incompatible with `Monitor.Wait/Pulse/PulseAll` — the wait/pulse family requires a reference type Monitor can install a sync block on. |
| `src/Core/DotCompute.Core/Messaging/MessageQueue.cs` | `_stripedLocks` (an `object[]`) | Collection-element lock array — per decision rule "Used as a dictionary value or collection element (you'd need boxing)". Leaving as-is to minimize diff surface. |

## What wasn't touched
- `src/Backends/DotCompute.Backends.CUDA/Hopper/` (recently landed, per request)
- `tests/` — follow-up task
- Fields already using the `Lock` type throughout the codebase

## Verification
- [x] `dotnet build DotCompute.sln --configuration Release` → **0 warnings, 0 errors**
- [x] Unit tests (Core + CPU Backend) → **511 passed, 0 failed** (486 Core, 25 CPU)
- [ ] LINQ + Architecture test assemblies hit a pre-existing `Castle.Core` dependency copy issue in the testhost — unrelated to this change, shows up on `main` as well.

## Test plan
- [ ] CI build passes on all configurations
- [ ] Unit-tested lock behaviour (Messaging, FaultTolerance, Barriers) still works under contention
- [ ] Downstream consumers (Orleans.GpuBridge.Core) unaffected — no public API changed
- [ ] Confirm no behaviour regression in BackpressureManager.Block strategy (unchanged — kept `object` there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)