### PR TITLE
chore: consolidate scattered hardware constants into HardwareConstants

### DIFF
--- a/src/Backends/DotCompute.Backends.CPU/Kernels/Simd/SimdOptimizationEngine.cs
+++ b/src/Backends/DotCompute.Backends.CPU/Kernels/Simd/SimdOptimizationEngine.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root for license information.
 
 using System.Runtime.CompilerServices;
+using DotCompute.Abstractions.Hardware;
 using DotCompute.Backends.CPU.Intrinsics;
 
 namespace DotCompute.Backends.CPU.Kernels.Simd;
@@ -125,9 +126,12 @@ public sealed class SimdOptimizationEngine(SimdSummary capabilities, ExecutorCon
         var totalBytes = elementCount * elementSize;
 
         // Rough cache size estimates (in bytes)
-        const long L1_CACHE_SIZE = 32 * 1024;      // 32KB typical L1
-        const long L2_CACHE_SIZE = 256 * 1024;     // 256KB typical L2
-        const long L3_CACHE_SIZE = 8 * 1024 * 1024; // 8MB typical L3
+        const long L1_CACHE_SIZE = HardwareConstants.CpuCache.L1Bytes;
+        const long L2_CACHE_SIZE = HardwareConstants.CpuCache.L2Bytes;
+        // NOTE: L3 here is a whole-package rough estimate (8 MB) and differs from
+        // HardwareConstants.CpuCache.L3BytesPerCore (2 MB per core) on purpose.
+        // Not migrated to avoid silently changing cache-efficiency thresholds.
+        const long L3_CACHE_SIZE = 8 * 1024 * 1024;
 
         if (totalBytes <= L1_CACHE_SIZE)
         {

--- a/src/Backends/DotCompute.Backends.CPU/SIMD/SimdMemoryOptimizer.cs
+++ b/src/Backends/DotCompute.Backends.CPU/SIMD/SimdMemoryOptimizer.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.ObjectModel;
 using System.Runtime.CompilerServices;
+using DotCompute.Abstractions.Hardware;
 using DotCompute.Backends.CPU.Kernels.Simd;
 using Microsoft.Extensions.Logging;
 
@@ -84,8 +85,8 @@ public sealed class SimdMemoryOptimizer(ExecutorConfiguration config, ILogger lo
     /// </summary>
     public static int CalculateOptimalBlockSize<T>(int dataSize) where T : unmanaged
     {
-        const int l1CacheSize = 32 * 1024; // 32KB L1 cache (typical)
-        const int l2CacheSize = 256 * 1024; // 256KB L2 cache (typical)
+        const int l1CacheSize = HardwareConstants.CpuCache.L1Bytes;
+        const int l2CacheSize = HardwareConstants.CpuCache.L2Bytes;
 
         var elementSize = Unsafe.SizeOf<T>();
         var elementsInL1 = l1CacheSize / elementSize;
@@ -184,7 +185,7 @@ public sealed class SimdMemoryOptimizer(ExecutorConfiguration config, ILogger lo
     /// </summary>
     private static double CalculateCacheEfficiency(int dataSize, int stride, int elementSize)
     {
-        const int cacheLineSize = 64; // bytes
+        const int cacheLineSize = HardwareConstants.CacheLine.Legacy64;
         var elementsPerCacheLine = cacheLineSize / elementSize;
 
         if (stride == 1)

--- a/src/Backends/DotCompute.Backends.CPU/Threading/NUMA/NumaSizes.cs
+++ b/src/Backends/DotCompute.Backends.CPU/Threading/NUMA/NumaSizes.cs
@@ -1,21 +1,26 @@
 // Copyright (c) 2025 Michael Ivertowski
 // Licensed under the MIT License. See LICENSE file in the project root for license information.
 
+using DotCompute.Abstractions.Hardware;
+
 namespace DotCompute.Backends.CPU.Threading.NUMA;
 
 /// <summary>
-/// Standard memory and cache sizes.
+/// Standard memory and cache sizes used by NUMA allocation helpers.
+/// Hardware-physical values re-export <see cref="HardwareConstants"/> so there
+/// is a single source of truth; HugePageSize stays local because 1 GB pages are
+/// a NUMA-specific policy choice rather than a universal hardware constant.
 /// </summary>
 internal static class NumaSizes
 {
-    /// <summary>Standard cache line size.</summary>
-    public const int CacheLineSize = 64;
+    /// <summary>Standard cache line size (64 bytes on most x86 parts).</summary>
+    public const int CacheLineSize = HardwareConstants.CacheLine.Legacy64;
 
     /// <summary>Standard page size.</summary>
-    public const int PageSize = 4096;
+    public const int PageSize = HardwareConstants.Alignment.Page;
 
     /// <summary>Large page size (2MB).</summary>
-    public const int LargePageSize = 2 * 1024 * 1024;
+    public const int LargePageSize = HardwareConstants.Alignment.LargePage;
 
     /// <summary>Huge page size (1GB).</summary>
     public const int HugePageSize = 1024 * 1024 * 1024;

--- a/src/Backends/DotCompute.Backends.CUDA/Memory/CudaMemoryPoolManager.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/Memory/CudaMemoryPoolManager.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using DotCompute.Abstractions.Hardware;
 using DotCompute.Backends.CUDA.Native;
 using DotCompute.Backends.CUDA.Types.Native;
 using Microsoft.Extensions.Logging;
@@ -24,9 +25,9 @@ namespace DotCompute.Backends.CUDA.Memory
         private bool _disposed;
 
         // Pool configuration
-        private const int MIN_POOL_SIZE = 256;                    // 256 bytes
-        private const int MAX_POOL_SIZE = 256 * 1024 * 1024;     // 256 MB
-        private const int POOL_SIZE_MULTIPLIER = 2;              // Size classes double
+        private const int MIN_POOL_SIZE = HardwareConstants.MemoryPool.MinClassBytes;
+        private const int MAX_POOL_SIZE = HardwareConstants.MemoryPool.MaxClassBytes;
+        private const int POOL_SIZE_MULTIPLIER = HardwareConstants.MemoryPool.SizeClassMultiplier;
         private const int MAX_BLOCKS_PER_POOL = 100;             // Maximum blocks per size class
         private const int MAINTENANCE_INTERVAL_SECONDS = 60;     // Cleanup interval
 

--- a/src/Backends/DotCompute.Backends.CUDA/Types/CudaMemoryAlignment.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/Types/CudaMemoryAlignment.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2025 Michael Ivertowski
 // Licensed under the MIT License. See LICENSE file in the project root for license information.
 
+using DotCompute.Abstractions.Hardware;
+
 namespace DotCompute.Backends.CUDA.Types
 {
     /// <summary>
@@ -9,9 +11,10 @@ namespace DotCompute.Backends.CUDA.Types
     public static class CudaMemoryAlignment
     {
         /// <summary>
-        /// The min alignment.
+        /// Minimum alignment for coalesced access (256 bytes).
+        /// Canonical source: <see cref="HardwareConstants.Alignment.Gpu"/>.
         /// </summary>
-        public const int MinAlignment = 256; // 256 bytes minimum for coalesced access
+        public const int MinAlignment = HardwareConstants.Alignment.Gpu;
         /// <summary>
         /// The optimal alignment.
         /// </summary>

--- a/src/Core/DotCompute.Abstractions/Hardware/HardwareConstants.cs
+++ b/src/Core/DotCompute.Abstractions/Hardware/HardwareConstants.cs
@@ -1,0 +1,105 @@
+// Copyright (c) 2025 Michael Ivertowski
+// Licensed under the MIT License. See LICENSE file in the project root for license information.
+
+// Nested public types are intentional here: they group physically-distinct domains
+// (cache, alignment, CUDA, CPU cache, memory pool) under one discoverable static
+// class so callers can write HardwareConstants.Cuda.WarpSize without disambiguation.
+#pragma warning disable CA1034 // Nested types should not be visible
+
+namespace DotCompute.Abstractions.Hardware;
+
+/// <summary>
+/// Hardware-physical constants used across backends. Single source of truth for
+/// values that are dictated by physical hardware (cache geometry, GPU alignment
+/// requirements, warp/block limits, etc.) rather than by application policy.
+/// </summary>
+/// <remarks>
+/// Values in this class MUST NOT vary across builds. If a value is tunable at
+/// runtime or differs between devices (e.g. per-SKU VRAM size, per-device warp
+/// count), it belongs in a device-info type, not here. Keep this class small and
+/// frozen — add new entries only when the same literal appears in three or more
+/// places.
+/// </remarks>
+public static class HardwareConstants
+{
+    /// <summary>
+    /// Cache-line-size constants. <see cref="Bytes"/> covers modern Zen4 and
+    /// NVIDIA Hopper L2 (128 B). <see cref="Legacy64"/> is the 64 B value that
+    /// most x86 parts (Intel/AMD pre-Zen4) and older CPUs use; migrated callers
+    /// that assumed 64 B should reference <see cref="Legacy64"/> explicitly.
+    /// </summary>
+    public static class CacheLine
+    {
+        /// <summary>Cache line size for modern architectures (128 bytes).</summary>
+        public const int Bytes = 128;
+
+        /// <summary>Legacy 64-byte cache line used by most x86 parts through Zen3.</summary>
+        public const int Legacy64 = 64;
+    }
+
+    /// <summary>
+    /// Memory alignment constants for GPU / SIMD operations.
+    /// </summary>
+    public static class Alignment
+    {
+        /// <summary>Minimum alignment for coalesced GPU access (CUDA, Metal).</summary>
+        public const int Gpu = 256;
+
+        /// <summary>AVX-512 vector alignment (64 bytes).</summary>
+        public const int SimdAvx512 = 64;
+
+        /// <summary>AVX2 vector alignment (32 bytes).</summary>
+        public const int SimdAvx2 = 32;
+
+        /// <summary>Standard memory page size (4 KB).</summary>
+        public const int Page = 4096;
+
+        /// <summary>Large memory page size (2 MB).</summary>
+        public const int LargePage = 2 * 1024 * 1024;
+    }
+
+    /// <summary>
+    /// CUDA thread / block / warp limits that are fixed by the CUDA architecture
+    /// (not per-device). Per-device values (SM count, L2 capacity, etc.) belong
+    /// on <see cref="DotCompute.Abstractions.AcceleratorInfo"/>.
+    /// </summary>
+    public static class Cuda
+    {
+        /// <summary>Maximum threads per CUDA block (all compute capabilities 2.0+).</summary>
+        public const int MaxThreadsPerBlock = 1024;
+
+        /// <summary>Warp size for NVIDIA GPUs.</summary>
+        public const int WarpSize = 32;
+    }
+
+    /// <summary>
+    /// Typical CPU cache sizes used for tiling heuristics. These are rough
+    /// defaults; when available, runtime-queried cache sizes should be preferred.
+    /// </summary>
+    public static class CpuCache
+    {
+        /// <summary>Typical L1 data cache size per core (32 KB).</summary>
+        public const int L1Bytes = 32 * 1024;
+
+        /// <summary>Typical L2 cache size per core (256 KB).</summary>
+        public const int L2Bytes = 256 * 1024;
+
+        /// <summary>Typical L3 cache budget per core (2 MB). Total L3 scales with core count.</summary>
+        public const int L3BytesPerCore = 2 * 1024 * 1024;
+    }
+
+    /// <summary>
+    /// Memory-pool size class boundaries for power-of-two pool allocators.
+    /// </summary>
+    public static class MemoryPool
+    {
+        /// <summary>Smallest pool size class (256 bytes).</summary>
+        public const int MinClassBytes = 256;
+
+        /// <summary>Largest pool size class (256 MB).</summary>
+        public const int MaxClassBytes = 256 * 1024 * 1024;
+
+        /// <summary>Growth factor between consecutive size classes (powers of two).</summary>
+        public const int SizeClassMultiplier = 2;
+    }
+}

--- a/src/Core/DotCompute.Core/Pipelines/Optimization/Utilities/IntelligentBufferSizeCalculator.cs
+++ b/src/Core/DotCompute.Core/Pipelines/Optimization/Utilities/IntelligentBufferSizeCalculator.cs
@@ -1,3 +1,4 @@
+using DotCompute.Abstractions.Hardware;
 using DotCompute.Abstractions.Types;
 
 namespace DotCompute.Core.Pipelines.Optimization.Utilities;
@@ -112,7 +113,7 @@ public static class IntelligentBufferSizeCalculator
     /// </summary>
     private static long AlignToCacheLine(long size)
     {
-        const int cacheLineSize = 64;
+        const int cacheLineSize = HardwareConstants.CacheLine.Legacy64;
         return ((size + cacheLineSize - 1) / cacheLineSize) * cacheLineSize;
     }
 

--- a/src/Extensions/DotCompute.Algorithms/Optimized/MemoryOptimizations.cs
+++ b/src/Extensions/DotCompute.Algorithms/Optimized/MemoryOptimizations.cs
@@ -7,6 +7,7 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics.X86;
+using DotCompute.Abstractions.Hardware;
 
 namespace DotCompute.Algorithms.Optimized;
 
@@ -17,9 +18,9 @@ namespace DotCompute.Algorithms.Optimized;
 public static class MemoryOptimizations
 {
     // Cache hierarchy parameters for modern CPUs
-    private const int L1_CACHE_SIZE = 32 * 1024;      // 32KB L1 cache
-    private const int L2_CACHE_SIZE = 256 * 1024;     // 256KB L2 cache
-    private const int CACHE_LINE_SIZE = 64;            // 64-byte cache line
+    private const int L1_CACHE_SIZE = HardwareConstants.CpuCache.L1Bytes;
+    private const int L2_CACHE_SIZE = HardwareConstants.CpuCache.L2Bytes;
+    private const int CACHE_LINE_SIZE = HardwareConstants.CacheLine.Legacy64;
     private const int PREFETCH_DISTANCE_L2 = 512;
 
 

--- a/src/Extensions/DotCompute.Algorithms/Optimized/ParallelOptimizations.cs
+++ b/src/Extensions/DotCompute.Algorithms/Optimized/ParallelOptimizations.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
+using DotCompute.Abstractions.Hardware;
 using DotCompute.Algorithms.LinearAlgebra;
 
 namespace DotCompute.Algorithms.Optimized;
@@ -660,7 +661,7 @@ public static class ParallelOptimizations
     private static int CalculateOptimalBlockSize(int rows, int cols, int inner)
     {
         // Cache-aware block size calculation
-        const int l2CacheSize = 256 * 1024; // 256KB L2 cache
+        const int l2CacheSize = HardwareConstants.CpuCache.L2Bytes;
         const int elementSize = sizeof(float);
 
 

--- a/tests/Unit/DotCompute.Abstractions.Tests/Hardware/HardwareConstantsTests.cs
+++ b/tests/Unit/DotCompute.Abstractions.Tests/Hardware/HardwareConstantsTests.cs
@@ -1,0 +1,126 @@
+// Copyright (c) 2025 Michael Ivertowski
+// Licensed under the MIT License. See LICENSE file in the project root for license information.
+
+using DotCompute.Abstractions.Hardware;
+
+namespace DotCompute.Abstractions.Tests.Hardware;
+
+/// <summary>
+/// Invariant tests for <see cref="HardwareConstants"/>. These guard against
+/// accidental changes to values that must remain physically consistent with the
+/// hardware they model.
+/// </summary>
+public class HardwareConstantsTests
+{
+    [Fact]
+    public void CacheLine_ModernBytes_IsPowerOfTwo()
+    {
+        HardwareConstants.CacheLine.Bytes.Should().Be(128);
+        IsPowerOfTwo(HardwareConstants.CacheLine.Bytes).Should().BeTrue();
+    }
+
+    [Fact]
+    public void CacheLine_Legacy64_IsPowerOfTwo()
+    {
+        HardwareConstants.CacheLine.Legacy64.Should().Be(64);
+        IsPowerOfTwo(HardwareConstants.CacheLine.Legacy64).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Alignment_GpuIsMultipleOfModernCacheLine()
+    {
+        // Coalesced GPU access must not straddle a cache line.
+        (HardwareConstants.Alignment.Gpu % HardwareConstants.CacheLine.Bytes)
+            .Should().Be(0, "GPU alignment must be a multiple of the cache line size");
+    }
+
+    [Fact]
+    public void Alignment_SimdSizesArePowersOfTwo()
+    {
+        IsPowerOfTwo(HardwareConstants.Alignment.SimdAvx2).Should().BeTrue();
+        IsPowerOfTwo(HardwareConstants.Alignment.SimdAvx512).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Alignment_Avx512DoubleOfAvx2()
+    {
+        // 512-bit SIMD lane = 2 x 256-bit SIMD lane.
+        HardwareConstants.Alignment.SimdAvx512
+            .Should().Be(HardwareConstants.Alignment.SimdAvx2 * 2);
+    }
+
+    [Fact]
+    public void Alignment_PageSizesArePowersOfTwo()
+    {
+        IsPowerOfTwo(HardwareConstants.Alignment.Page).Should().BeTrue();
+        IsPowerOfTwo(HardwareConstants.Alignment.LargePage).Should().BeTrue();
+        (HardwareConstants.Alignment.LargePage % HardwareConstants.Alignment.Page)
+            .Should().Be(0);
+    }
+
+    [Fact]
+    public void Cuda_MaxThreadsPerBlockIs1024()
+    {
+        // Fixed by CUDA architecture for all compute capabilities 2.0+.
+        HardwareConstants.Cuda.MaxThreadsPerBlock.Should().Be(1024);
+    }
+
+    [Fact]
+    public void Cuda_WarpSizeIs32()
+    {
+        HardwareConstants.Cuda.WarpSize.Should().Be(32);
+    }
+
+    [Fact]
+    public void Cuda_MaxThreadsPerBlockIsMultipleOfWarpSize()
+    {
+        (HardwareConstants.Cuda.MaxThreadsPerBlock % HardwareConstants.Cuda.WarpSize)
+            .Should().Be(0);
+    }
+
+    [Fact]
+    public void CpuCache_HierarchyIsMonotonic()
+    {
+        HardwareConstants.CpuCache.L1Bytes.Should()
+            .BeLessThan(HardwareConstants.CpuCache.L2Bytes);
+        HardwareConstants.CpuCache.L2Bytes.Should()
+            .BeLessThan(HardwareConstants.CpuCache.L3BytesPerCore);
+    }
+
+    [Fact]
+    public void CpuCache_SizesArePowersOfTwo()
+    {
+        IsPowerOfTwo(HardwareConstants.CpuCache.L1Bytes).Should().BeTrue();
+        IsPowerOfTwo(HardwareConstants.CpuCache.L2Bytes).Should().BeTrue();
+        IsPowerOfTwo(HardwareConstants.CpuCache.L3BytesPerCore).Should().BeTrue();
+    }
+
+    [Fact]
+    public void MemoryPool_MinClassIsPowerOfTwo()
+    {
+        IsPowerOfTwo(HardwareConstants.MemoryPool.MinClassBytes).Should().BeTrue();
+    }
+
+    [Fact]
+    public void MemoryPool_MaxClassIsPowerOfTwo()
+    {
+        IsPowerOfTwo(HardwareConstants.MemoryPool.MaxClassBytes).Should().BeTrue();
+    }
+
+    [Fact]
+    public void MemoryPool_MaxClassReachableFromMinWithMultiplier()
+    {
+        var size = HardwareConstants.MemoryPool.MinClassBytes;
+        var steps = 0;
+        while (size < HardwareConstants.MemoryPool.MaxClassBytes && steps < 64)
+        {
+            size *= HardwareConstants.MemoryPool.SizeClassMultiplier;
+            steps++;
+        }
+        size.Should().Be(
+            HardwareConstants.MemoryPool.MaxClassBytes,
+            "MaxClassBytes must be reachable from MinClassBytes via SizeClassMultiplier");
+    }
+
+    private static bool IsPowerOfTwo(int value) => value > 0 && (value & (value - 1)) == 0;
+}


### PR DESCRIPTION
## Summary

- Creates `src/Core/DotCompute.Abstractions/Hardware/HardwareConstants.cs` as a single source of truth for hardware-physical values (cache line, GPU/SIMD alignment, CUDA warp/block limits, CPU cache tiers, memory-pool size classes).
- Migrates 8 scattered call sites — across CPU, CUDA, Core, and Algorithms — from duplicated numeric literals to typed references in `HardwareConstants.*`.
- Adds 14 invariant tests covering power-of-two-ness, cache-hierarchy monotonicity, warp/block alignment relationships, and pool reachability.

## Migration table (file → value → new constant)

| File | Old literal | New constant |
|------|-------------|--------------|
| `SimdMemoryOptimizer.cs` | `32 * 1024` (L1) | `HardwareConstants.CpuCache.L1Bytes` |
| `SimdMemoryOptimizer.cs` | `256 * 1024` (L2) | `HardwareConstants.CpuCache.L2Bytes` |
| `SimdMemoryOptimizer.cs` | `64` (cache line) | `HardwareConstants.CacheLine.Legacy64` |
| `SimdOptimizationEngine.cs` | `32 * 1024` (L1) | `HardwareConstants.CpuCache.L1Bytes` |
| `SimdOptimizationEngine.cs` | `256 * 1024` (L2) | `HardwareConstants.CpuCache.L2Bytes` |
| `MemoryOptimizations.cs` (Algorithms) | `32 * 1024`, `256 * 1024`, `64` | `L1Bytes`, `L2Bytes`, `CacheLine.Legacy64` |
| `ParallelOptimizations.cs` (Algorithms) | `256 * 1024` (L2) | `HardwareConstants.CpuCache.L2Bytes` |
| `IntelligentBufferSizeCalculator.cs` | `64` (cache line) | `HardwareConstants.CacheLine.Legacy64` |
| `NumaSizes.cs` | `64`, `4096`, `2 * 1024 * 1024` | `CacheLine.Legacy64`, `Alignment.Page`, `Alignment.LargePage` |
| `CudaMemoryPoolManager.cs` | `256`, `256 * 1024 * 1024`, `2` | `MemoryPool.MinClassBytes`, `MaxClassBytes`, `SizeClassMultiplier` |
| `CudaMemoryAlignment.cs` | `MinAlignment = 256` | `HardwareConstants.Alignment.Gpu` (public constant now delegates) |

## Values that were *different* and left alone (flagged for review)

- **`SimdOptimizationEngine.cs` `L3_CACHE_SIZE = 8 * 1024 * 1024`** — intentionally different from `HardwareConstants.CpuCache.L3BytesPerCore = 2 * 1024 * 1024`. The former is a whole-package rough estimate; the latter is per-core. Swapping would silently change cache-efficiency thresholds. Left with an inline comment explaining the divergence.
- **`CudaMemoryAlignment.OptimalAlignment = 512`** — RTX-2000-specific tuning, distinct from the generic 256 B GPU minimum. Left in place; only `MinAlignment` delegates to `HardwareConstants.Alignment.Gpu`.
- **`NumaSizes.HugePageSize = 1 * 1024 * 1024 * 1024`** — NUMA-specific policy, not a universal hardware constant. Left local.

## Scope limits respected

- No changes to Hopper preview code or `RTX2000Specs` (device-specific specs stay where they live).
- `DotCompute.Generators` is `netstandard2.0` and cannot reference the `net10.0` Abstractions assembly, so its `GeneratorConstants.CacheLineSize` was left as a local constant. Can be addressed later if the generator moves to a compatible TFM.
- Public API surface: `CudaMemoryAlignment.MinAlignment` still exists with the same value (it just delegates to `HardwareConstants.Alignment.Gpu` via `const` expression, so downstream callers see no change). No `[Obsolete]` attributes were needed.

## Verification

- `dotnet build DotCompute.sln --configuration Release` → 0 errors, 0 warnings.
- `dotnet test --filter Category=Unit` → no regressions. DotCompute.Abstractions.Tests: 691 passed (14 new + existing). DotCompute.Core.Tests: 486 passed. DotCompute.Backends.CPU.Tests: 25 passed.
- `Grep` confirms the new file is referenced by all 8 migrated sites.

## Test plan

- [x] Build succeeds clean on net10.0 with TreatWarningsAsErrors.
- [x] New invariant tests pass locally (14/14).
- [x] Existing unit tests unchanged (no behavioral drift).
- [ ] Reviewer: confirm `L3_CACHE_SIZE = 8 MB` vs `L3BytesPerCore = 2 MB` divergence is the intended behavior and doesn't need a unification pass.
- [ ] Reviewer: confirm `CudaMemoryAlignment.OptimalAlignment = 512` should stay RTX-2000-specific or be folded into `HardwareConstants`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)