### PR TITLE
chore: improve error messages with actionable context

### DIFF
--- a/src/Backends/DotCompute.Backends.CPU/CpuMemoryBuffer.cs
+++ b/src/Backends/DotCompute.Backends.CPU/CpuMemoryBuffer.cs
@@ -52,9 +52,9 @@ public sealed class CpuMemoryBuffer : IUnifiedMemoryBuffer<byte>, IDisposable
     {
         _sizeInBytes = sizeInBytes;
         _options = options;
-        _memoryManager = memoryManager ?? throw new ArgumentNullException(nameof(memoryManager));
+        _memoryManager = memoryManager ?? throw new ArgumentNullException(nameof(memoryManager), "CpuMemoryBuffer requires a non-null CpuMemoryManager for tracking and cleanup. Obtain one via cpuAccelerator.Memory or construct via CpuMemoryManager directly.");
         _numaNode = numaNode;
-        _policy = policy ?? throw new ArgumentNullException(nameof(policy));
+        _policy = policy ?? throw new ArgumentNullException(nameof(policy), "CpuMemoryBuffer requires a non-null NumaMemoryPolicy. Use NumaMemoryPolicy.CreateDefault() if you have no explicit NUMA preference.");
         _logger = logger;
         _state = BufferState.HostOnly;
 
@@ -351,7 +351,7 @@ public sealed class CpuMemoryBuffer : IUnifiedMemoryBuffer<byte>, IDisposable
         if (source.Length > _sizeInBytes)
         {
 
-            throw new ArgumentException("Source is larger than buffer");
+            throw new ArgumentException($"CpuMemoryBuffer.CopyFromAsync source length ({source.Length} bytes) exceeds buffer capacity ({_sizeInBytes} bytes). Shrink the source, or allocate a larger buffer via cpuAccelerator.Memory.AllocateAsync<byte>(size).", nameof(source));
         }
 
 
@@ -372,7 +372,7 @@ public sealed class CpuMemoryBuffer : IUnifiedMemoryBuffer<byte>, IDisposable
         if (destination.Length < _sizeInBytes)
         {
 
-            throw new ArgumentException("Destination is smaller than buffer");
+            throw new ArgumentException($"CpuMemoryBuffer.CopyToAsync destination length ({destination.Length} bytes) is smaller than buffer size ({_sizeInBytes} bytes). Allocate a destination with at least buffer.SizeInBytes bytes, or use CopyToAsync(sourceOffset, destination, destinationOffset, count) for a partial copy.", nameof(destination));
         }
 
 
@@ -497,7 +497,7 @@ public sealed class CpuMemoryBuffer : IUnifiedMemoryBuffer<byte>, IDisposable
         if (_sizeInBytes % elementSize != 0)
         {
 
-            throw new InvalidOperationException($"Buffer size {_sizeInBytes} is not compatible with element size {elementSize}");
+            throw new InvalidOperationException($"CpuMemoryBuffer.AsType<{typeof(TNew).Name}> failed: buffer size {_sizeInBytes} bytes is not evenly divisible by sizeof({typeof(TNew).Name}) ({elementSize} bytes). Reinterpretation requires buffer size to be a whole multiple of the target element size. Pad the buffer to {((_sizeInBytes + elementSize - 1) / elementSize) * elementSize} bytes, or choose a compatible element type.");
         }
 
         // Calculate new element count

--- a/src/Backends/DotCompute.Backends.CPU/CpuMemoryManager.cs
+++ b/src/Backends/DotCompute.Backends.CPU/CpuMemoryManager.cs
@@ -19,7 +19,7 @@ public sealed class CpuMemoryManager(ILogger<CpuMemoryManager> logger, NumaMemor
 {
     private readonly Threading.NUMA.NumaTopology _topology = NumaInfo.Topology;
     private readonly NumaMemoryPolicy _defaultPolicy = defaultPolicy ?? NumaMemoryPolicy.CreateDefault();
-    private readonly ILogger<CpuMemoryManager> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    private readonly ILogger<CpuMemoryManager> _logger = logger ?? throw new ArgumentNullException(nameof(logger), "A logger is required for CpuMemoryManager. Register one via services.AddLogging() or pass NullLogger<CpuMemoryManager>.Instance in unit tests.");
 
     /// <summary>
     /// Gets NUMA topology information.
@@ -86,7 +86,7 @@ public sealed class CpuMemoryManager(ILogger<CpuMemoryManager> logger, NumaMemor
         }
 
 
-        throw new ArgumentException("Buffer must be a CPU memory buffer", nameof(buffer));
+        throw new ArgumentException($"CpuMemoryManager.CreateViewCore requires a CpuMemoryBuffer, but received {buffer.GetType().Name}. Cross-backend views are not supported — allocate via cpuAccelerator.Memory.AllocateAsync<T>() to produce a CpuMemoryBuffer, or copy a device buffer to host via CopyFromDeviceAsync before creating a CPU-side view.", nameof(buffer));
     }
 
     private static NumaMemoryPolicy CreateDefaultPolicy()
@@ -398,7 +398,9 @@ public sealed class CpuMemoryManager(ILogger<CpuMemoryManager> logger, NumaMemor
             // Validate parameters
             if (offset < 0 || length < 0 || offset + length > parent.SizeInBytes)
             {
-                throw new ArgumentOutOfRangeException(nameof(offset), "Invalid view parameters");
+                throw new ArgumentOutOfRangeException(
+                    nameof(offset),
+                    $"Invalid view parameters: offset={offset}, length={length}, buffer size={parent.SizeInBytes} bytes. Ensure offset >= 0, length >= 0, and offset + length <= buffer.SizeInBytes.");
             }
 
             // Create a shared view that references the parent buffer
@@ -440,7 +442,7 @@ public sealed class CpuMemoryManager(ILogger<CpuMemoryManager> logger, NumaMemor
             }
             else
             {
-                throw new ArgumentException("Both buffers must be CPU memory buffers");
+                throw new ArgumentException($"CpuMemoryManager.CopyAsync requires both source and destination to be CPU memory buffers, but received source={source.GetType().Name}, destination={destination.GetType().Name}. For cross-backend copies use the orchestrator's CopyToDeviceAsync / CopyFromDeviceAsync on the target buffer's memory manager.");
             }
 
             return ValueTask.CompletedTask;
@@ -472,21 +474,21 @@ public sealed class CpuMemoryManager(ILogger<CpuMemoryManager> logger, NumaMemor
                 if (sourceOffset < 0 || destinationOffset < 0 || count < 0)
                 {
 
-                    throw new ArgumentOutOfRangeException(nameof(sourceOffset), "Negative offsets or count not allowed");
+                    throw new ArgumentOutOfRangeException(nameof(sourceOffset), $"Offsets and count must be non-negative (got sourceOffset={sourceOffset}, destinationOffset={destinationOffset}, count={count}).");
                 }
 
 
                 if (sourceOffset + count > sourceSpan.Length)
                 {
 
-                    throw new ArgumentOutOfRangeException(nameof(count), "Source range exceeds buffer size");
+                    throw new ArgumentOutOfRangeException(nameof(count), $"Source range exceeds buffer bounds: sourceOffset({sourceOffset}) + count({count}) = {sourceOffset + count}, but source length is {sourceSpan.Length}.");
                 }
 
 
                 if (destinationOffset + count > destSpan.Length)
                 {
 
-                    throw new ArgumentOutOfRangeException(nameof(destinationOffset), "Destination range exceeds buffer size");
+                    throw new ArgumentOutOfRangeException(nameof(destinationOffset), $"Destination range exceeds buffer bounds: destinationOffset({destinationOffset}) + count({count}) = {destinationOffset + count}, but destination length is {destSpan.Length}.");
                 }
 
                 // Perform offset-based copy
@@ -499,7 +501,7 @@ public sealed class CpuMemoryManager(ILogger<CpuMemoryManager> logger, NumaMemor
             }
             else
             {
-                throw new ArgumentException("Both buffers must be CPU memory buffers");
+                throw new ArgumentException($"CpuMemoryManager.CopyAsync (with offsets) requires both source and destination to be CPU memory buffers, but received source={source.GetType().Name}, destination={destination.GetType().Name}. For cross-backend copies use the orchestrator's CopyToDeviceAsync / CopyFromDeviceAsync on the target buffer's memory manager.");
             }
 
             return ValueTask.CompletedTask;
@@ -533,7 +535,7 @@ public sealed class CpuMemoryManager(ILogger<CpuMemoryManager> logger, NumaMemor
             }
             else
             {
-                throw new ArgumentException("Source must be a CPU memory buffer");
+                throw new ArgumentException($"CpuMemoryManager.CopyFromDeviceAsync expects a CpuMemoryBuffer source, but received {source.GetType().Name}. Invoke CopyFromDeviceAsync on the source buffer's own memory manager (e.g. CudaMemoryManager) instead.", nameof(source));
             }
 
             return ValueTask.CompletedTask;
@@ -567,7 +569,7 @@ public sealed class CpuMemoryManager(ILogger<CpuMemoryManager> logger, NumaMemor
             }
             else
             {
-                throw new ArgumentException("Destination must be a CPU memory buffer");
+                throw new ArgumentException($"CpuMemoryManager.CopyToDeviceAsync expects a CpuMemoryBuffer destination, but received {destination.GetType().Name}. Invoke CopyToDeviceAsync on the destination buffer's own memory manager (e.g. CudaMemoryManager) instead.", nameof(destination));
             }
 
             return ValueTask.CompletedTask;
@@ -604,7 +606,7 @@ public sealed class CpuMemoryManager(ILogger<CpuMemoryManager> logger, NumaMemor
             }
             else
             {
-                throw new ArgumentException("Buffer must be a CPU memory buffer");
+                throw new ArgumentException($"CpuMemoryManager.CreateView<{typeof(T).Name}> requires a CPU memory buffer, but received {buffer.GetType().Name}. Allocate the buffer via cpuAccelerator.Memory.AllocateAsync<{typeof(T).Name}>(count) to produce a CPU-compatible buffer.", nameof(buffer));
             }
         }
         catch (Exception ex)

--- a/src/Backends/DotCompute.Backends.CUDA/CudaAccelerator.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/CudaAccelerator.cs
@@ -202,7 +202,7 @@ namespace DotCompute.Backends.CUDA
                 var result = CudaRuntime.cudaDeviceSynchronize();
                 if (result != CudaError.Success)
                 {
-                    throw new InvalidOperationException($"CUDA synchronization failed: {CudaRuntime.GetErrorString(result)}");
+                    throw new InvalidOperationException($"CUDA device synchronization (cudaDeviceSynchronize) failed on device {DeviceId}: {CudaRuntime.GetErrorString(result)} (error code {(int)result}). A prior kernel launch or memcpy likely produced a runtime error. Re-run with compute-sanitizer (or cuda-memcheck) to locate the faulting launch, or enable detailed CUDA logging.");
                 }
             }, cancellationToken).ConfigureAwait(false);
         }
@@ -305,7 +305,7 @@ namespace DotCompute.Backends.CUDA
             var result = CudaRuntime.cudaDeviceReset();
             if (result != CudaError.Success)
             {
-                throw new InvalidOperationException($"CUDA device reset failed: {CudaRuntime.GetErrorString(result)}");
+                throw new InvalidOperationException($"CUDA device reset (cudaDeviceReset) failed on device {DeviceId}: {CudaRuntime.GetErrorString(result)} (error code {(int)result}). Device reset affects all CUDA contexts on this device; other processes may also be impacted. Ensure no outstanding device work is running on another thread before calling Reset().");
             }
 
             // Reinitialize context
@@ -403,7 +403,7 @@ namespace DotCompute.Backends.CUDA
             catch (Exception ex)
             {
                 LogDeviceInitFailed(logger, ex, deviceId);
-                throw new InvalidOperationException($"Failed to initialize CUDA device {deviceId}", ex);
+                throw new InvalidOperationException($"Failed to initialize CUDA device {deviceId}. Common causes: (1) no NVIDIA GPU present — run `nvidia-smi` to verify; (2) CUDA driver missing or version mismatch; (3) on WSL2, LD_LIBRARY_PATH must include /usr/lib/wsl/lib (see docs/guides/wsl2-setup.md); (4) deviceId out of range — this host exposes devices 0..N-1 where N is cudaGetDeviceCount. See inner exception for the underlying CUDA error.", ex);
             }
         }
 

--- a/src/Backends/DotCompute.Backends.CUDA/Memory/CudaMemoryManager.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/Memory/CudaMemoryManager.cs
@@ -93,9 +93,9 @@ namespace DotCompute.Backends.CUDA.Memory
         /// <param name="logger">The logger.</param>
 
         public CudaMemoryManager(CudaContext context, CudaDevice? device, ILogger logger)
-            : base(logger ?? throw new ArgumentNullException(nameof(logger)))
+            : base(logger ?? throw new ArgumentNullException(nameof(logger), "A logger is required for CudaMemoryManager. Register one via services.AddLogging() or pass NullLogger.Instance in unit tests."))
         {
-            _context = context ?? throw new ArgumentNullException(nameof(context));
+            _context = context ?? throw new ArgumentNullException(nameof(context), "CudaMemoryManager requires an initialized CudaContext. Construct one via new CudaContext(deviceId) or obtain it from cudaAccelerator.Context.");
             _device = device ?? new CudaDevice(context.DeviceId, logger);
             _logger = logger;
             _allocations = new ConcurrentDictionary<IntPtr, long>();
@@ -138,7 +138,7 @@ namespace DotCompute.Backends.CUDA.Memory
         public override long MaxAllocationSize => _maxAllocationSize;
 
         /// <inheritdoc/>
-        public override IAccelerator Accelerator => _accelerator ?? throw new InvalidOperationException("Accelerator not set. Call SetAccelerator first.");
+        public override IAccelerator Accelerator => _accelerator ?? throw new InvalidOperationException("CudaMemoryManager.Accelerator is not set. This typically means the memory manager was used before its owning CudaAccelerator finished construction. If constructing manually, call SetAccelerator(accelerator) after the CudaAccelerator is instantiated, or obtain the manager via cudaAccelerator.Memory.");
 
         /// <inheritdoc/>
         public override MemoryStatistics Statistics => GetCudaMemoryStatistics();
@@ -616,7 +616,7 @@ namespace DotCompute.Backends.CUDA.Memory
             if (source.Length > destination.Length)
             {
 
-                throw new ArgumentException("Source data exceeds destination buffer size", nameof(source));
+                throw new ArgumentException($"CudaMemoryManager.CopyToDeviceAsync source length ({source.Length} {typeof(T).Name} elements) exceeds destination buffer length ({destination.Length}). Shrink the source, or allocate a destination buffer with at least {source.Length} elements via memory.AllocateAsync<{typeof(T).Name}>({source.Length}).", nameof(source));
             }
 
 
@@ -646,7 +646,7 @@ namespace DotCompute.Backends.CUDA.Memory
             if (source.Length > destination.Length)
             {
 
-                throw new ArgumentException("Source buffer size exceeds destination capacity", nameof(source));
+                throw new ArgumentException($"CudaMemoryManager.CopyFromDeviceAsync source buffer length ({source.Length} {typeof(T).Name} elements) exceeds destination capacity ({destination.Length}). Allocate a larger destination Memory<{typeof(T).Name}> with at least {source.Length} elements, or copy a slice via buffer.Slice(offset, count).CopyToAsync(...).", nameof(source));
             }
 
 
@@ -699,9 +699,7 @@ namespace DotCompute.Backends.CUDA.Memory
 
             // Non-generic views are not supported for CUDA buffers. Callers should use the
             // typed CreateView<T> overload which delegates to CudaMemoryBuffer<T>.Slice.
-            throw new NotSupportedException(
-                "Non-generic buffer views are not supported for CUDA memory. " +
-                "Use the generic CreateView<T>(buffer, offset, length) overload instead.");
+            throw new NotSupportedException($"CudaMemoryManager does not support non-generic views over IUnifiedMemoryBuffer (received {buffer.GetType().Name}). Use the generic overload CreateView<T>(IUnifiedMemoryBuffer<T>, int offset, int length) so element size is known, or call buffer.Slice(offset, count) directly on a typed buffer.");
         }
 
         /// <summary>
@@ -717,7 +715,7 @@ namespace DotCompute.Backends.CUDA.Memory
             }
             catch (Exception ex)
             {
-                throw new InvalidOperationException("Failed to dispose memory manager asynchronously", ex);
+                throw new InvalidOperationException($"CudaMemoryManager.DisposeAsync failed for device {_context?.DeviceId ?? -1}. This may indicate leaked allocations or that CUDA was already shut down. See inner exception for the underlying CUDA error.", ex);
             }
         }
         /// <summary>
@@ -953,7 +951,7 @@ namespace DotCompute.Backends.CUDA.Memory
             {
                 CudaMemoryBuffer<T> cudaTypedBuffer => cudaTypedBuffer.DevicePointer,
                 CudaMemoryBuffer cudaBuffer => cudaBuffer.DevicePointer,
-                _ => throw new ArgumentException($"Unsupported buffer type: {buffer.GetType().Name}", nameof(buffer))
+                _ => throw new ArgumentException($"CUDA operations require a CudaMemoryBuffer<{typeof(T).Name}> or CudaMemoryBuffer, but received {buffer.GetType().Name}. Allocate the buffer via cudaAccelerator.Memory.AllocateAsync<{typeof(T).Name}>(count) — passing a CPU or foreign-backend buffer directly is not supported.", nameof(buffer))
             };
         }
 
@@ -965,7 +963,7 @@ namespace DotCompute.Backends.CUDA.Memory
             return buffer switch
             {
                 CudaMemoryBuffer cudaBuffer => cudaBuffer.DevicePointer,
-                _ => throw new ArgumentException($"Unsupported buffer type: {buffer.GetType().Name}", nameof(buffer))
+                _ => throw new ArgumentException($"CUDA operations require a CudaMemoryBuffer, but received {buffer.GetType().Name}. Allocate the buffer via cudaAccelerator.Memory.AllocateAsync<T>(count) — passing a CPU or foreign-backend buffer directly is not supported.", nameof(buffer))
             };
         }
     }

--- a/src/Core/DotCompute.Abstractions/Interfaces/IAccelerator.cs
+++ b/src/Core/DotCompute.Abstractions/Interfaces/IAccelerator.cs
@@ -269,37 +269,37 @@ namespace DotCompute.Abstractions
         {
             if (string.IsNullOrEmpty(name))
             {
-                throw new ArgumentException("Name cannot be null or empty", nameof(name));
+                throw new ArgumentException("AcceleratorInfo.Name cannot be null or empty. Provide a human-readable device name such as 'NVIDIA RTX 2000 Ada Generation'.", nameof(name));
             }
 
             if (string.IsNullOrEmpty(vendor))
             {
-                throw new ArgumentException("Vendor cannot be null or empty", nameof(vendor));
+                throw new ArgumentException("AcceleratorInfo.Vendor cannot be null or empty. Provide the hardware vendor (e.g. 'NVIDIA', 'AMD', 'Intel', 'Apple', 'Arm').", nameof(vendor));
             }
 
             if (string.IsNullOrEmpty(driverVersion))
             {
-                throw new ArgumentException("DriverVersion cannot be null or empty", nameof(driverVersion));
+                throw new ArgumentException("AcceleratorInfo.DriverVersion cannot be null or empty. Provide the driver version string reported by the device (e.g. '581.15' for NVIDIA).", nameof(driverVersion));
             }
 
             if (computeCapability <= 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(computeCapability), "ComputeCapability must be positive");
+                throw new ArgumentOutOfRangeException(nameof(computeCapability), computeCapability, $"AcceleratorInfo.ComputeCapability must be a positive number (got {computeCapability}). CUDA uses values like 8.9 for Ada Lovelace; use 0 only when not applicable.");
             }
 
             if (maxThreadsPerBlock <= 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(maxThreadsPerBlock), "MaxThreadsPerBlock must be positive");
+                throw new ArgumentOutOfRangeException(nameof(maxThreadsPerBlock), maxThreadsPerBlock, $"AcceleratorInfo.MaxThreadsPerBlock must be > 0 (got {maxThreadsPerBlock}). Typical GPU values are 512 or 1024; CPUs should report Environment.ProcessorCount or similar.");
             }
 
             if (maxSharedMemory < 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(maxSharedMemory), "MaxSharedMemory cannot be negative");
+                throw new ArgumentOutOfRangeException(nameof(maxSharedMemory), maxSharedMemory, $"AcceleratorInfo.MaxSharedMemory cannot be negative (got {maxSharedMemory}). Use 0 for devices without on-chip shared memory.");
             }
 
             if (totalMemory <= 0 || availableMemory <= 0 || availableMemory > totalMemory)
             {
-                throw new ArgumentException("Invalid memory sizes");
+                throw new ArgumentException($"Invalid memory sizes: totalMemory={totalMemory}, availableMemory={availableMemory}. Both must be > 0 and availableMemory must not exceed totalMemory.");
             }
 
             Id = $"{type}_{name}";

--- a/src/Core/DotCompute.Abstractions/Kernels/BytecodeKernelSource.cs
+++ b/src/Core/DotCompute.Abstractions/Kernels/BytecodeKernelSource.cs
@@ -29,17 +29,17 @@ namespace DotCompute.Abstractions.Kernels
 
             if (bytecode.Length == 0)
             {
-                throw new ArgumentException("Bytecode cannot be empty", nameof(bytecode));
+                throw new ArgumentException($"BytecodeKernelSource.Bytecode cannot be empty. Provide non-empty {language} bytecode (e.g. compiled PTX, CUBIN, SPIR-V, or metallib).", nameof(bytecode));
             }
 
             if (string.IsNullOrEmpty(name))
             {
-                throw new ArgumentException("Name cannot be null or empty", nameof(name));
+                throw new ArgumentException("BytecodeKernelSource.Name cannot be null or empty. Provide a unique identifier for the kernel (it is used for caching and diagnostics).", nameof(name));
             }
 
             if (string.IsNullOrEmpty(entryPoint))
             {
-                throw new ArgumentException("EntryPoint cannot be null or empty", nameof(entryPoint));
+                throw new ArgumentException("BytecodeKernelSource.EntryPoint cannot be null or empty. Provide the exported function name defined inside the bytecode (must match the symbol name as emitted by the compiler).", nameof(entryPoint));
             }
 
             Code = Convert.ToBase64String(bytecode);

--- a/src/Core/DotCompute.Abstractions/Kernels/KernelParameter.cs
+++ b/src/Core/DotCompute.Abstractions/Kernels/KernelParameter.cs
@@ -17,8 +17,8 @@ public class KernelParameter
     /// <exception cref="ArgumentNullException">Thrown when name or type is null.</exception>
     public KernelParameter(string name, Type type, ParameterDirection direction)
     {
-        Name = name ?? throw new ArgumentNullException(nameof(name));
-        Type = type ?? throw new ArgumentNullException(nameof(type));
+        Name = name ?? throw new ArgumentNullException(nameof(name), "KernelParameter.Name cannot be null. Provide the parameter name as it appears in the kernel source (e.g. 'input', 'output', 'length').");
+        Type = type ?? throw new ArgumentNullException(nameof(type), "KernelParameter.Type cannot be null. Provide a System.Type for the parameter such as typeof(float[]) for buffers or typeof(int) for scalars.");
         Direction = direction;
         Index = -1; // Default value when not specified
         IsInput = direction is ParameterDirection.In or ParameterDirection.InOut;
@@ -38,8 +38,8 @@ public class KernelParameter
     /// <param name="isConstant">Whether this is a constant parameter.</param>
     public KernelParameter(string name, Type type, int index, bool isInput = true, bool isOutput = false, bool isConstant = false)
     {
-        Name = name ?? throw new ArgumentNullException(nameof(name));
-        Type = type ?? throw new ArgumentNullException(nameof(type));
+        Name = name ?? throw new ArgumentNullException(nameof(name), "KernelParameter.Name cannot be null. Provide the parameter name as it appears in the kernel source (e.g. 'input', 'output', 'length').");
+        Type = type ?? throw new ArgumentNullException(nameof(type), "KernelParameter.Type cannot be null. Provide a System.Type for the parameter such as typeof(float[]) for buffers or typeof(int) for scalars.");
         Index = index;
         IsInput = isInput;
         IsOutput = isOutput;

--- a/src/Core/DotCompute.Abstractions/Kernels/TextKernelSource.cs
+++ b/src/Core/DotCompute.Abstractions/Kernels/TextKernelSource.cs
@@ -26,17 +26,17 @@ namespace DotCompute.Abstractions.Kernels
         {
             if (string.IsNullOrEmpty(code))
             {
-                throw new ArgumentException("Code cannot be null or empty", nameof(code));
+                throw new ArgumentException($"TextKernelSource.Code cannot be null or empty. Provide the kernel source text in the {language} dialect (e.g. a CUDA __global__ function body or OpenCL __kernel).", nameof(code));
             }
 
             if (string.IsNullOrEmpty(name))
             {
-                throw new ArgumentException("Name cannot be null or empty", nameof(name));
+                throw new ArgumentException("TextKernelSource.Name cannot be null or empty. Provide a unique identifier for the kernel (it is used for caching and diagnostics).", nameof(name));
             }
 
             if (string.IsNullOrEmpty(entryPoint))
             {
-                throw new ArgumentException("EntryPoint cannot be null or empty", nameof(entryPoint));
+                throw new ArgumentException($"TextKernelSource.EntryPoint cannot be null or empty. Provide the exported function name defined inside the source code (e.g. 'vectorAdd' matching __global__ void vectorAdd(...)).", nameof(entryPoint));
             }
 
             Code = code;

--- a/src/Core/DotCompute.Core/Memory/BaseMemoryManager.cs
+++ b/src/Core/DotCompute.Core/Memory/BaseMemoryManager.cs
@@ -28,7 +28,9 @@ public abstract partial class BaseMemoryManager(ILogger logger) : IUnifiedMemory
     #endregion
 
     private readonly ConcurrentDictionary<IUnifiedMemoryBuffer, WeakReference<IUnifiedMemoryBuffer>> _activeBuffers = new();
-    private readonly ILogger _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    private readonly ILogger _logger = logger ?? throw new ArgumentNullException(
+        nameof(logger),
+        "A logger is required for BaseMemoryManager. Register one via services.AddLogging() or pass NullLogger.Instance in unit tests.");
 
     /// <summary>
     /// Gets the logger instance for derived classes.
@@ -194,7 +196,7 @@ public abstract partial class BaseMemoryManager(ILogger logger) : IUnifiedMemory
         catch (Exception ex)
         {
             _logger.LogErrorMessage(ex, $"Failed to allocate {sizeInBytes} bytes");
-            throw new InvalidOperationException($"Memory allocation failed for {sizeInBytes} bytes", ex);
+            throw new InvalidOperationException($"Memory allocation of {sizeInBytes} bytes failed on {Accelerator?.Info?.DeviceType ?? "unknown device"}. Current usage: {CurrentAllocatedMemory} / {TotalAvailableMemory} bytes. Verify the requested size is within device memory and MaxAllocationSize; free unused buffers or reduce the allocation size.", ex);
         }
     }
 
@@ -258,7 +260,7 @@ public abstract partial class BaseMemoryManager(ILogger logger) : IUnifiedMemory
         }
         else
         {
-            throw new InvalidOperationException($"Buffer is not of type IUnifiedMemoryBuffer<{typeof(T).Name}>");
+            throw new InvalidOperationException($"CopyToDevice<{typeof(T).Name}> requires a buffer implementing IUnifiedMemoryBuffer<{typeof(T).Name}>, but received {buffer.GetType().Name}. Allocate the buffer via memoryManager.AllocateAsync<{typeof(T).Name}>(count) so its element type matches the copy operation.");
         }
     }
 
@@ -286,7 +288,7 @@ public abstract partial class BaseMemoryManager(ILogger logger) : IUnifiedMemory
         }
         else
         {
-            throw new InvalidOperationException($"Buffer is not of type IUnifiedMemoryBuffer<{typeof(T).Name}>");
+            throw new InvalidOperationException($"CopyFromDevice<{typeof(T).Name}> requires a buffer implementing IUnifiedMemoryBuffer<{typeof(T).Name}>, but received {buffer.GetType().Name}. Allocate the buffer via memoryManager.AllocateAsync<{typeof(T).Name}>(count) so its element type matches the copy operation.");
         }
     }
 
@@ -317,8 +319,8 @@ public abstract partial class BaseMemoryManager(ILogger logger) : IUnifiedMemory
         // Legacy API: Backend-specific implementations should override this
         // Base implementation throws NotSupportedException
         throw new NotSupportedException(
-            "AllocateDevice is a legacy API that requires backend-specific implementation. " +
-            "Use AllocateAsync<T> for new code.");
+            $"AllocateDevice({sizeInBytes} bytes) is a legacy raw-pointer API and is not implemented on the base memory manager. " +
+            "Use AllocateAsync<T>(count) which returns a managed IUnifiedMemoryBuffer<T>, or override AllocateDevice in a backend-specific memory manager.");
     }
 
     /// <inheritdoc/>

--- a/src/Extensions/DotCompute.Linq/ServiceCollectionExtensions.cs
+++ b/src/Extensions/DotCompute.Linq/ServiceCollectionExtensions.cs
@@ -46,7 +46,7 @@ internal sealed class ComputeLinqProvider : IComputeLinqProvider
 
     public ComputeLinqProvider(ILogger<ComputeLinqProvider> logger)
     {
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger), "A logger is required for ComputeLinqProvider. Register one via services.AddLogging() before calling AddDotComputeLinq(), or pass NullLogger<ComputeLinqProvider>.Instance in unit tests.");
     }
 
     [RequiresUnreferencedCode("LINQ expressions may reference methods that could be trimmed.")]

--- a/src/Runtime/DotCompute.Runtime/Factories/DefaultAcceleratorFactory.cs
+++ b/src/Runtime/DotCompute.Runtime/Factories/DefaultAcceleratorFactory.cs
@@ -79,13 +79,13 @@ public class DefaultAcceleratorFactory : IUnifiedAcceleratorFactory, IDisposable
             // Parse accelerator type
             if (!Enum.TryParse<AcceleratorType>(acceleratorInfo.DeviceType, true, out var acceleratorType))
             {
-                throw new ArgumentException($"Unsupported accelerator type: {acceleratorInfo.DeviceType}");
+                throw new ArgumentException($"Unsupported accelerator type '{acceleratorInfo.DeviceType}'. Recognized types are: {string.Join(", ", Enum.GetNames<AcceleratorType>())}. Set AcceleratorInfo.DeviceType to one of these values (case-insensitive).", nameof(acceleratorInfo));
             }
 
             // Check if we can create this type
             if (!CanCreateAccelerator(acceleratorType))
             {
-                throw new NotSupportedException($"Accelerator type {acceleratorType} is not supported");
+                throw new NotSupportedException($"Accelerator type {acceleratorType} is not supported on this host. Available types: {string.Join(", ", GetSupportedTypes())}. Either install the missing backend package (e.g. DotCompute.Backends.CUDA) or register a custom IAcceleratorProvider via factory.RegisterProvider(...).");
             }
 
             // Get or create provider
@@ -247,7 +247,7 @@ public class DefaultAcceleratorFactory : IUnifiedAcceleratorFactory, IDisposable
     {
         if (!Enum.TryParse<AcceleratorType>(backendName, true, out var type))
         {
-            throw new ArgumentException($"Unknown backend name: {backendName}", nameof(backendName));
+            throw new ArgumentException($"Unknown backend name '{backendName}'. Recognized names (case-insensitive): {string.Join(", ", Enum.GetNames<AcceleratorType>())}. Pass one of these or use the AcceleratorType enum overload directly.", nameof(backendName));
         }
 
 
@@ -368,7 +368,7 @@ public class DefaultAcceleratorFactory : IUnifiedAcceleratorFactory, IDisposable
 
         if (!typeof(IAcceleratorProvider).IsAssignableFrom(providerType))
         {
-            throw new ArgumentException($"Provider type {providerType.Name} must implement IAcceleratorProvider");
+            throw new ArgumentException($"Provider type {providerType.Name} must implement IAcceleratorProvider, but it does not. Inherit from IAcceleratorProvider (or AcceleratorProviderBase) and re-register, or pass a different type to RegisterProvider.", nameof(providerType));
         }
 
         foreach (var type in supportedTypes)
@@ -427,7 +427,7 @@ public class DefaultAcceleratorFactory : IUnifiedAcceleratorFactory, IDisposable
             return (IAcceleratorProvider)provider;
         }
 
-        throw new NotSupportedException($"No provider found for accelerator type {type}");
+        throw new NotSupportedException($"No IAcceleratorProvider registered for accelerator type {type}. Available types: {string.Join(", ", _providerTypes.Keys)}. Install the missing backend package (e.g. DotCompute.Backends.{type}) or register a provider via factory.RegisterProvider(typeof(MyProvider), {type}).");
     }
 
     [RequiresUnreferencedCode("Creating provider instances requires runtime type information")]

--- a/src/Runtime/DotCompute.Runtime/Providers/CpuAcceleratorProvider.cs
+++ b/src/Runtime/DotCompute.Runtime/Providers/CpuAcceleratorProvider.cs
@@ -58,7 +58,7 @@ public class CpuAcceleratorProvider : IAcceleratorProvider
 
         if (_cpuAcceleratorType == null)
         {
-            throw new NotSupportedException("CPU backend is not available. Install DotCompute.Backends.CPU package.");
+            throw new NotSupportedException("CPU backend assembly was not found. Add a PackageReference to DotCompute.Backends.CPU in your project — the CPU backend should always be available, so a missing reference is the most likely cause.");
         }
 
         // Get logger from service provider
@@ -68,7 +68,7 @@ public class CpuAcceleratorProvider : IAcceleratorProvider
         // Create CPU accelerator using reflection (always available)
         if (Activator.CreateInstance(_cpuAcceleratorType, logger) is not IAccelerator accelerator)
         {
-            throw new InvalidOperationException("Failed to create CPU accelerator instance");
+            throw new InvalidOperationException("Failed to create CPU accelerator instance. Activator.CreateInstance returned null or a non-IAccelerator object — this typically means a constructor mismatch in DotCompute.Backends.CPU.CpuAccelerator. Verify the package versions of DotCompute.Runtime and DotCompute.Backends.CPU match.");
         }
 
         return ValueTask.FromResult(accelerator);

--- a/src/Runtime/DotCompute.Runtime/Providers/CudaAcceleratorProvider.cs
+++ b/src/Runtime/DotCompute.Runtime/Providers/CudaAcceleratorProvider.cs
@@ -58,7 +58,7 @@ public class CudaAcceleratorProvider : IAcceleratorProvider
 
         if (_cudaAcceleratorType == null)
         {
-            throw new NotSupportedException("CUDA backend is not available. Install DotCompute.Backends.CUDA package.");
+            throw new NotSupportedException("CUDA backend assembly was not found. Add a PackageReference to DotCompute.Backends.CUDA in your project, ensure the NVIDIA GPU driver is installed, and verify the runtime can locate libcuda (on WSL2 set LD_LIBRARY_PATH=/usr/lib/wsl/lib:$LD_LIBRARY_PATH).");
         }
 
         // Extract device ID from the info
@@ -71,7 +71,7 @@ public class CudaAcceleratorProvider : IAcceleratorProvider
         // Create CUDA accelerator using reflection
         if (Activator.CreateInstance(_cudaAcceleratorType, deviceId, logger) is not IAccelerator accelerator)
         {
-            throw new InvalidOperationException("Failed to create CUDA accelerator instance");
+            throw new InvalidOperationException($"Failed to create CUDA accelerator instance for device {deviceId}. Activator.CreateInstance returned null or a non-IAccelerator object — this typically means a constructor mismatch in DotCompute.Backends.CUDA.CudaAccelerator. Verify the package versions of DotCompute.Runtime and DotCompute.Backends.CUDA match.");
         }
 
         return ValueTask.FromResult(accelerator);

--- a/src/Runtime/DotCompute.Runtime/Providers/MetalAcceleratorProvider.cs
+++ b/src/Runtime/DotCompute.Runtime/Providers/MetalAcceleratorProvider.cs
@@ -58,7 +58,7 @@ public class MetalAcceleratorProvider : IAcceleratorProvider
 
         if (_metalAcceleratorType == null)
         {
-            throw new NotSupportedException("Metal backend is not available. Metal is only supported on macOS. Install DotCompute.Backends.Metal package.");
+            throw new NotSupportedException("Metal backend assembly was not found. Metal is supported only on macOS — verify you are running on macOS (current OS: " + Environment.OSVersion.Platform + ") and add a PackageReference to DotCompute.Backends.Metal in your project.");
         }
 
         // Extract device ID from the info
@@ -71,7 +71,7 @@ public class MetalAcceleratorProvider : IAcceleratorProvider
         // Create Metal accelerator using reflection
         if (Activator.CreateInstance(_metalAcceleratorType, deviceId, logger) is not IAccelerator accelerator)
         {
-            throw new InvalidOperationException("Failed to create Metal accelerator instance");
+            throw new InvalidOperationException($"Failed to create Metal accelerator instance for device {deviceId}. Activator.CreateInstance returned null or a non-IAccelerator object — this typically means a constructor mismatch in DotCompute.Backends.Metal.MetalAccelerator. Verify the package versions of DotCompute.Runtime and DotCompute.Backends.Metal match.");
         }
 
         return ValueTask.FromResult(accelerator);

--- a/src/Runtime/DotCompute.Runtime/ServiceCollectionExtensions.cs
+++ b/src/Runtime/DotCompute.Runtime/ServiceCollectionExtensions.cs
@@ -138,7 +138,7 @@ public static class ServiceCollectionExtensions
         {
             if (!typeof(IAcceleratorProvider).IsAssignableFrom(providerType))
             {
-                throw new ArgumentException($"Type {providerType.Name} does not implement IAcceleratorProvider");
+                throw new ArgumentException($"AddDotComputeRuntimeWithProviders: type {providerType.Name} does not implement IAcceleratorProvider. The provider type must inherit from IAcceleratorProvider. Pass a class such as CudaAcceleratorProvider, CpuAcceleratorProvider, MetalAcceleratorProvider, or your own implementation.", nameof(providerTypes));
             }
 
 #pragma warning disable IL2072 // Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' - Plugin system requires runtime type registration

--- a/src/Runtime/DotCompute.Runtime/Services/KernelExecutionService.cs
+++ b/src/Runtime/DotCompute.Runtime/Services/KernelExecutionService.cs
@@ -131,7 +131,7 @@ public class KernelExecutionService(
     {
         try
         {
-            var accelerator = await GetOptimalAcceleratorAsync(kernelName) ?? throw new InvalidOperationException($"No suitable accelerator found for kernel: {kernelName}");
+            var accelerator = await GetOptimalAcceleratorAsync(kernelName) ?? throw new InvalidOperationException($"No suitable accelerator found for kernel '{kernelName}'. No accelerators are registered with the runtime — register at least one backend (e.g. services.AddDotComputeRuntime().AddCpuBackend()) before executing kernels, or pass an IAccelerator explicitly via ExecuteAsync<T>(kernelName, accelerator, args).");
             return await ExecuteAsync<T>(kernelName, accelerator, args);
         }
         catch (Exception ex)
@@ -154,7 +154,7 @@ public class KernelExecutionService(
             return await ExecuteAsync<T>(kernelName, args);
         }
 
-        var accelerator = accelerators.OrderBy(GetAcceleratorLoad).FirstOrDefault() ?? throw new InvalidOperationException($"No suitable {preferredBackend} accelerator found");
+        var accelerator = accelerators.OrderBy(GetAcceleratorLoad).FirstOrDefault() ?? throw new InvalidOperationException($"No suitable '{preferredBackend}' accelerator found for kernel '{kernelName}'. Available device types: {string.Join(", ", _runtime.GetAccelerators().Select(a => a.Info.DeviceType).Distinct())}. Pass a recognized backend name (CPU, CUDA, Metal) or omit preferredBackend to use the optimal accelerator.");
         return await ExecuteAsync<T>(kernelName, accelerator, args);
     }
 
@@ -165,14 +165,14 @@ public class KernelExecutionService(
 
         if (!_kernelRegistry.TryGetValue(kernelName, out var registration))
         {
-            throw new ArgumentException($"Kernel not found: {kernelName}", nameof(kernelName));
+            throw new ArgumentException($"Kernel '{kernelName}' is not registered. Registered kernels: [{string.Join(", ", _kernelRegistry.Keys)}]. Add the kernel via RegisterKernel() before executing, or check for typos.", nameof(kernelName));
         }
 
         // Validate arguments
         var isValid = await ValidateKernelArgsAsync(kernelName, args);
         if (!isValid)
         {
-            throw new ArgumentException($"Kernel argument validation failed for kernel: {kernelName}");
+            throw new ArgumentException($"Kernel argument validation failed for kernel '{kernelName}' (received {args?.Length ?? 0} arguments). Verify argument count, types, and ordering match the kernel signature; enable debug logging for detailed validation output.", nameof(args));
         }
 
         // Get or compile kernel
@@ -255,7 +255,7 @@ public class KernelExecutionService(
     {
         if (!_kernelRegistry.TryGetValue(kernelName, out var registration))
         {
-            throw new ArgumentException($"Kernel not found: {kernelName}", nameof(kernelName));
+            throw new ArgumentException($"Cannot precompile: kernel '{kernelName}' is not registered. Registered kernels: [{string.Join(", ", _kernelRegistry.Keys)}]. Add the kernel via RegisterKernel() before precompiling.", nameof(kernelName));
         }
 
         var acceleratorsToPrecompile = accelerator != null
@@ -421,7 +421,7 @@ public class KernelExecutionService(
         try
         {
             // Get the memory manager from the accelerator
-            var memoryManager = accelerator.Memory ?? throw new InvalidOperationException("Accelerator does not have a memory manager available");
+            var memoryManager = accelerator.Memory ?? throw new InvalidOperationException($"Accelerator '{accelerator.Info?.Name ?? "unknown"}' (type {accelerator.Info?.DeviceType ?? "?"}) returned a null Memory manager. This indicates the accelerator was not fully initialized — check the constructor of your custom IAccelerator implementation, or report this against the backend.");
 
             // Handle different array types by creating proper unified buffers
             return array switch
@@ -435,7 +435,7 @@ public class KernelExecutionService(
                 ulong[] ulongArray => await CreateUnifiedBufferAsync(ulongArray, memoryManager),
                 short[] shortArray => await CreateUnifiedBufferAsync(shortArray, memoryManager),
                 ushort[] ushortArray => await CreateUnifiedBufferAsync(ushortArray, memoryManager),
-                _ => throw new NotSupportedException($"Array type {array.GetType()} is not supported for conversion to UnifiedBuffer")
+                _ => throw new NotSupportedException($"Array element type {array.GetType().GetElementType()?.Name ?? array.GetType().Name} is not supported for automatic UnifiedBuffer conversion. Supported element types: float, double, int, uint, long, ulong, short, ushort, byte. For other unmanaged types, allocate the buffer explicitly via memoryManager.AllocateAsync<T>(count) and copy your array in.")
             };
         }
         catch (Exception ex)
@@ -449,7 +449,7 @@ public class KernelExecutionService(
                 double[] doubleArray => new MockUnifiedBuffer<double>(doubleArray),
                 int[] intArray => new MockUnifiedBuffer<int>(intArray),
                 byte[] byteArray => new MockUnifiedBuffer<byte>(byteArray),
-                _ => throw new NotSupportedException($"Array type {array.GetType()} is not supported for conversion to UnifiedBuffer")
+                _ => throw new NotSupportedException($"Array element type {array.GetType().GetElementType()?.Name ?? array.GetType().Name} is not supported for automatic UnifiedBuffer conversion. Supported element types: float, double, int, uint, long, ulong, short, ushort, byte. For other unmanaged types, allocate the buffer explicitly via memoryManager.AllocateAsync<T>(count) and copy your array in.")
             };
         }
     }
@@ -489,7 +489,7 @@ public class KernelExecutionService(
             return default!;
         }
 
-        throw new InvalidOperationException($"Cannot convert result type {result.GetType()} to {typeof(T)}");
+        throw new InvalidOperationException($"Kernel result type {result.GetType().Name} cannot be converted to {typeof(T).Name}. Update the ExecuteAsync<T> generic argument to match the kernel's actual return type, or perform an explicit conversion before assigning.");
     }
 
     private static async Task<T> ExtractExecutionResultAsync<T>(ICompiledKernel compiledKernel, KernelArguments kernelArgs, IAccelerator accelerator)


### PR DESCRIPTION
## Summary

Audit of production exception messages scored the average at 3/5. This pass raises ~64 throw sites to 4/5+ by adding the triggering operation, the offending value or state, and a one-line hint for the likely fix. Scope is narrowly user-visible code paths — no test changes, no resource-string churn, no style-only refactors.

## Before / after examples

### 1. CPU memory-manager buffer type mismatch

```csharp
// Before (2/5)
throw new ArgumentException("Buffer must be a CPU memory buffer", nameof(buffer));

// After (4/5)
throw new ArgumentException(
    $"CpuMemoryManager.CreateViewCore requires a CpuMemoryBuffer, but received {buffer.GetType().Name}. " +
    "Cross-backend views are not supported — allocate via cpuAccelerator.Memory.AllocateAsync<T>() to produce a CpuMemoryBuffer, " +
    "or copy a device buffer to host via CopyFromDeviceAsync before creating a CPU-side view.",
    nameof(buffer));
```

### 2. CUDA synchronization failure

```csharp
// Before (3/5)
throw new InvalidOperationException($"CUDA synchronization failed: {CudaRuntime.GetErrorString(result)}");

// After (4/5)
throw new InvalidOperationException(
    $"CUDA device synchronization (cudaDeviceSynchronize) failed on device {DeviceId}: " +
    $"{CudaRuntime.GetErrorString(result)} (error code {(int)result}). " +
    "A prior kernel launch or memcpy likely produced a runtime error. " +
    "Re-run with compute-sanitizer (or cuda-memcheck) to locate the faulting launch.");
```

### 3. CUDA device initialization failure

```csharp
// Before
throw new InvalidOperationException($"Failed to initialize CUDA device {deviceId}", ex);

// After
throw new InvalidOperationException(
    $"Failed to initialize CUDA device {deviceId}. Common causes: " +
    "(1) no NVIDIA GPU present — run `nvidia-smi` to verify; " +
    "(2) CUDA driver missing or version mismatch; " +
    "(3) on WSL2, LD_LIBRARY_PATH must include /usr/lib/wsl/lib (see docs/guides/wsl2-setup.md); " +
    "(4) deviceId out of range — this host exposes devices 0..N-1 where N is cudaGetDeviceCount. " +
    "See inner exception for the underlying CUDA error.",
    ex);
```

### 4. Kernel not registered

```csharp
// Before (2/5)
throw new ArgumentException($"Kernel not found: {kernelName}", nameof(kernelName));

// After (4/5)
throw new ArgumentException(
    $"Kernel '{kernelName}' is not registered. Registered kernels: [{string.Join(", ", _kernelRegistry.Keys)}]. " +
    "Add the kernel via RegisterKernel() before executing, or check for typos.",
    nameof(kernelName));
```

### 5. Unsupported array type in ExecuteAsync

```csharp
// Before
throw new NotSupportedException($"Array type {array.GetType()} is not supported for conversion to UnifiedBuffer");

// After
throw new NotSupportedException(
    $"Array element type {array.GetType().GetElementType()?.Name ?? array.GetType().Name} is not supported for automatic UnifiedBuffer conversion. " +
    "Supported element types: float, double, int, uint, long, ulong, short, ushort, byte. " +
    "For other unmanaged types, allocate the buffer explicitly via memoryManager.AllocateAsync<T>(count) and copy your array in.");
```

## Files touched (16)

- `src/Core/DotCompute.Core/Memory/BaseMemoryManager.cs`
- `src/Backends/DotCompute.Backends.CPU/CpuMemoryManager.cs`
- `src/Backends/DotCompute.Backends.CPU/CpuMemoryBuffer.cs`
- `src/Backends/DotCompute.Backends.CUDA/Memory/CudaMemoryManager.cs`
- `src/Backends/DotCompute.Backends.CUDA/CudaAccelerator.cs`
- `src/Core/DotCompute.Abstractions/Interfaces/IAccelerator.cs`
- `src/Core/DotCompute.Abstractions/Kernels/KernelParameter.cs`
- `src/Core/DotCompute.Abstractions/Kernels/TextKernelSource.cs`
- `src/Core/DotCompute.Abstractions/Kernels/BytecodeKernelSource.cs`
- `src/Runtime/DotCompute.Runtime/Factories/DefaultAcceleratorFactory.cs`
- `src/Runtime/DotCompute.Runtime/Providers/{Cpu,Cuda,Metal}AcceleratorProvider.cs`
- `src/Runtime/DotCompute.Runtime/ServiceCollectionExtensions.cs`
- `src/Runtime/DotCompute.Runtime/Services/KernelExecutionService.cs`
- `src/Extensions/DotCompute.Linq/ServiceCollectionExtensions.cs`

## Verification

- `dotnet build DotCompute.sln --configuration Release` → 0 errors, 0 warnings
- Unit tests: no tests assert on the old message text, so nothing required updating
- Three pre-existing flaky timing/concurrency tests (`PumpThread_GpuTransferFailure_DropsMessages`, `ConcurrentErrors_MultipleThreads_ShouldHandleGracefully`, `RecoveryCoordinator_StrategySelection_EfficientRouting`) occasionally fail under load but pass in isolation and are unrelated to exception text

## Test plan

- [ ] Verify build remains 0 warnings / 0 errors on CI
- [ ] Spot-check unit tests still pass (`dotnet test DotCompute.sln --filter Category=Unit`)
- [ ] Confirm improved messages render well when triggered manually (e.g. pass wrong buffer type, wrong array element type, nonexistent kernel name)

🤖 Generated with [Claude Code](https://claude.com/claude-code)