### PR TITLE
chore: improve error messages in execution/recovery/pipelines/ringkernels (wave 2)

### DIFF
--- a/src/Backends/DotCompute.Backends.CUDA/Execution/CudaEventManager.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/Execution/CudaEventManager.cs
@@ -38,8 +38,12 @@ namespace DotCompute.Backends.CUDA.Execution
 
         public CudaEventManager(CudaContext context, ILogger<CudaEventManager> logger)
         {
-            _context = context ?? throw new ArgumentNullException(nameof(context));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _context = context ?? throw new ArgumentNullException(
+                nameof(context),
+                "CudaContext is required for CudaEventManager. Each event is bound to a context and records on a stream within that context — obtain it from the owning CudaAccelerator.");
+            _logger = logger ?? throw new ArgumentNullException(
+                nameof(logger),
+                "ILogger<CudaEventManager> is required. Register logging via AddLogging() so event lifecycle and timing diagnostics are captured.");
             _activeEvents = new ConcurrentDictionary<EventId, CudaEventInfo>();
             _timingSessions = new ConcurrentDictionary<string, CudaTimingSession>();
             _eventCreationSemaphore = new SemaphoreSlim(MAX_CONCURRENT_EVENTS, MAX_CONCURRENT_EVENTS);
@@ -179,7 +183,9 @@ namespace DotCompute.Backends.CUDA.Execution
 
             if (!_activeEvents.TryGetValue(eventId, out var eventInfo))
             {
-                throw new ArgumentException($"Event {eventId} not found", nameof(eventId));
+                throw new ArgumentException(
+                    $"CudaEventManager has no active event with id {eventId}. The event was never created, or was already destroyed via DestroyEvent. Create events via CreateEvent(...) before recording or synchronizing on them.",
+                    nameof(eventId));
             }
 
             _context.MakeCurrent();
@@ -216,7 +222,9 @@ namespace DotCompute.Backends.CUDA.Execution
 
             if (!_activeEvents.TryGetValue(eventId, out var eventInfo))
             {
-                throw new ArgumentException($"Event {eventId} not found", nameof(eventId));
+                throw new ArgumentException(
+                    $"CudaEventManager has no active event with id {eventId}. The event was never created, or was already destroyed via DestroyEvent. Create events via CreateEvent(...) before recording or synchronizing on them.",
+                    nameof(eventId));
             }
 
             _context.MakeCurrent();
@@ -237,7 +245,8 @@ namespace DotCompute.Backends.CUDA.Execution
                 }
                 catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
                 {
-                    throw new TimeoutException($"Event {eventId} synchronization timed out after {timeout}");
+                    throw new TimeoutException(
+                        $"cudaEventSynchronize({eventId}) timed out after {timeout}. The kernel/copy that was supposed to signal this event has not completed within the deadline. Check device queue depth, kernel progress (nvidia-smi), or increase the timeout.");
                 }
             }
             else
@@ -285,17 +294,22 @@ namespace DotCompute.Backends.CUDA.Execution
 
             if (!_activeEvents.TryGetValue(startEvent, out var startInfo))
             {
-                throw new ArgumentException($"Start event {startEvent} not found");
+                throw new ArgumentException(
+                    $"Start event {startEvent} was not found in CudaEventManager. Create it via CreateEvent(CudaEventType.Timing) and RecordEvent before measuring elapsed time.",
+                    nameof(startEvent));
             }
 
             if (!_activeEvents.TryGetValue(endEvent, out var endInfo))
             {
-                throw new ArgumentException($"End event {endEvent} not found");
+                throw new ArgumentException(
+                    $"End event {endEvent} was not found in CudaEventManager. Create it via CreateEvent(CudaEventType.Timing) and RecordEvent before measuring elapsed time.",
+                    nameof(endEvent));
             }
 
             if (startInfo.Type != CudaEventType.Timing || endInfo.Type != CudaEventType.Timing)
             {
-                throw new InvalidOperationException("Both events must be timing events");
+                throw new InvalidOperationException(
+                    $"MeasureElapsedTime requires both events to be CudaEventType.Timing (start={startInfo.Type}, end={endInfo.Type}). Timing events must be created with CreateEvent(CudaEventType.Timing, ...) — other event types lack the timing bit and cannot be differenced.");
             }
 
             _context.MakeCurrent();
@@ -490,7 +504,9 @@ namespace DotCompute.Backends.CUDA.Execution
 
             if (!_activeEvents.TryGetValue(eventId, out var eventInfo))
             {
-                throw new ArgumentException($"Event {eventId} not found");
+                throw new ArgumentException(
+                    $"Cannot add callback: event {eventId} is not active in CudaEventManager. Create and record the event before AddEventCallback.",
+                    nameof(eventId));
             }
 
             _ = Task.Run(async () =>
@@ -548,7 +564,9 @@ namespace DotCompute.Backends.CUDA.Execution
                 return MeasureElapsedTime(startInfo.EventId, endInfo.EventId);
             }
 
-            throw new ArgumentException("One or both events not found", nameof(startEvent));
+            throw new ArgumentException(
+                $"ElapsedTime: could not resolve one or both event handles to active events (startEvent=0x{startEvent.ToInt64():X} {(startInfo == null ? "not found" : "ok")}, endEvent=0x{endEvent.ToInt64():X} {(endInfo == null ? "not found" : "ok")}). Use the handles returned by CreateEvent and do not destroy events before measuring elapsed time.",
+                nameof(startEvent));
         }
 
         /// <summary>

--- a/src/Backends/DotCompute.Backends.CUDA/Execution/CudaGraphSupport.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/Execution/CudaGraphSupport.cs
@@ -52,10 +52,18 @@ namespace DotCompute.Backends.CUDA.Execution
             CudaEventManager eventManager,
             ILogger<CudaGraphSupport> logger)
         {
-            _context = context ?? throw new ArgumentNullException(nameof(context));
-            _streamManager = streamManager ?? throw new ArgumentNullException(nameof(streamManager));
-            _eventManager = eventManager ?? throw new ArgumentNullException(nameof(eventManager));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _context = context ?? throw new ArgumentNullException(
+                nameof(context),
+                "CudaContext is required for CudaGraphSupport. Obtain it from CudaAccelerator.Context — graphs are context-bound resources.");
+            _streamManager = streamManager ?? throw new ArgumentNullException(
+                nameof(streamManager),
+                "CudaStreamManager is required for CudaGraphSupport to capture and launch graphs. Share a stream manager across subsystems.");
+            _eventManager = eventManager ?? throw new ArgumentNullException(
+                nameof(eventManager),
+                "CudaEventManager is required for CudaGraphSupport to measure graph-launch timings.");
+            _logger = logger ?? throw new ArgumentNullException(
+                nameof(logger),
+                "ILogger<CudaGraphSupport> is required for graph-capture/instantiate/launch diagnostics.");
 
             _graphInstances = new ConcurrentDictionary<string, CudaGraphInstance>();
             _graphTemplates = new ConcurrentDictionary<string, CudaGraph>();
@@ -138,7 +146,9 @@ namespace DotCompute.Backends.CUDA.Execution
 
             if (!_graphTemplates.TryGetValue(graphId, out var graph))
             {
-                throw new ArgumentException($"Graph {graphId} not found", nameof(graphId));
+                throw new ArgumentException(
+                    $"CUDA graph template '{graphId}' is not registered. Registered templates: [{string.Join(", ", _graphTemplates.Keys)}]. Call CreateGraphAsync/CaptureAsync to register a template before InstantiateGraphAsync.",
+                    nameof(graphId));
             }
 
             _context.MakeCurrent();
@@ -197,7 +207,8 @@ namespace DotCompute.Backends.CUDA.Execution
 
             if (!instance.IsValid)
             {
-                throw new InvalidOperationException("Graph instance is not valid");
+                throw new InvalidOperationException(
+                    $"CudaGraphInstance '{instance.Id}' (graph template '{instance.GraphId}') is not valid — it was either never successfully instantiated, was already disposed, or was invalidated by a dependent graph update. Re-instantiate via InstantiateGraphAsync before launching.");
             }
 
             _context.MakeCurrent();

--- a/src/Backends/DotCompute.Backends.CUDA/Execution/CudaKernelExecutor.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/Execution/CudaKernelExecutor.cs
@@ -47,11 +47,21 @@ namespace DotCompute.Backends.CUDA.Execution
             CudaEventManager eventManager,
             ILogger<CudaKernelExecutor> logger)
         {
-            _accelerator = accelerator ?? throw new ArgumentNullException(nameof(accelerator));
-            _context = context ?? throw new ArgumentNullException(nameof(context));
-            _streamManager = streamManager ?? throw new ArgumentNullException(nameof(streamManager));
-            _eventManager = eventManager ?? throw new ArgumentNullException(nameof(eventManager));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _accelerator = accelerator ?? throw new ArgumentNullException(
+                nameof(accelerator),
+                "CudaKernelExecutor requires the target IAccelerator — it owns device resources and memory allocations. Pass the accelerator that produced the kernel being executed.");
+            _context = context ?? throw new ArgumentNullException(
+                nameof(context),
+                "CudaContext is required for CudaKernelExecutor. Obtain it via CudaAccelerator.Context or CudaContextManager.");
+            _streamManager = streamManager ?? throw new ArgumentNullException(
+                nameof(streamManager),
+                "CudaStreamManager is required for CudaKernelExecutor to schedule async kernel launches. Share a stream manager across executors to reuse stream handles.");
+            _eventManager = eventManager ?? throw new ArgumentNullException(
+                nameof(eventManager),
+                "CudaEventManager is required for CudaKernelExecutor to coordinate timing and completion signals. Share an event manager across executors to reuse event handles.");
+            _logger = logger ?? throw new ArgumentNullException(
+                nameof(logger),
+                "ILogger<CudaKernelExecutor> is required for launch/complete/error diagnostics. Register logging via AddLogging() in DI.");
             _launcher = new CudaKernelLauncher(context, logger);
             _activeExecutions = new ConcurrentDictionary<Guid, CudaKernelExecution>();
             _executionSemaphore = new SemaphoreSlim(Environment.ProcessorCount * 2, Environment.ProcessorCount * 2);
@@ -245,7 +255,8 @@ namespace DotCompute.Backends.CUDA.Execution
 
             if (!_activeExecutions.TryGetValue(handle.Id, out var execution))
             {
-                throw new InvalidOperationException($"Execution handle {handle.Id} not found");
+                throw new InvalidOperationException(
+                    $"KernelExecutionHandle {handle.Id} is not known to CudaKernelExecutor. Either execution already completed and was harvested, or the handle belongs to a different executor. Call WaitForCompletionAsync only once per handle, and only with a handle returned by this executor's ExecuteAsync.");
             }
 
             // Wait for completion with cancellation support
@@ -328,7 +339,8 @@ namespace DotCompute.Backends.CUDA.Execution
                     break;
 
                 default:
-                    throw new NotSupportedException($"Problem dimensions > 3 not supported: {dimensions}");
+                    throw new NotSupportedException(
+                        $"CUDA kernel launch supports 1-D, 2-D, or 3-D grids only (received {dimensions}-D problem size). Reshape the problem into a 3-D block decomposition, or split into multiple smaller launches.");
             }
 
             return new KernelExecutionConfig
@@ -379,7 +391,9 @@ namespace DotCompute.Backends.CUDA.Execution
 
             if (timings.Count == 0)
             {
-                throw new InvalidOperationException("No successful executions for profiling");
+                throw new InvalidOperationException(
+                    $"Profiling found no successful kernel executions after {iterations} iteration(s) — every run failed or returned no timing data. " +
+                    $"Inspect per-iteration error logs (set log level to Debug) to find the underlying kernel failures. Fix those before reporting profile statistics.");
             }
 
             timings.Sort();
@@ -436,7 +450,8 @@ namespace DotCompute.Backends.CUDA.Execution
                 2 => CudaLaunchConfig.Create2D(globalSize[0], globalSize[1], localSize[0], localSize[1]),
                 3 => CudaLaunchConfig.Create3D(globalSize[0], globalSize[1], globalSize[2],
                                         localSize[0], localSize[1], localSize[2]),
-                _ => throw new NotSupportedException($"Dimensions > 3 not supported: {globalSize.Count}"),
+                _ => throw new NotSupportedException(
+                    $"CudaLaunchConfig supports 1-D, 2-D, or 3-D grids only (received {globalSize.Count}-D GlobalWorkSize). CUDA's launch model is capped at 3 dimensions — reshape the problem or split into multiple launches."),
             };
 
         }
@@ -490,7 +505,9 @@ namespace DotCompute.Backends.CUDA.Execution
         CancellationToken cancellationToken = default)
         {
             // Convert CompiledKernel struct to CudaCompiledKernel
-            var cudaKernel = CudaCompiledKernel.FromCompiledKernel(kernel) ?? throw new ArgumentException("Kernel must be a valid CUDA kernel", nameof(kernel));
+            var cudaKernel = CudaCompiledKernel.FromCompiledKernel(kernel) ?? throw new ArgumentException(
+                $"Kernel '{kernel.Name}' (id={kernel.Id}) is a {kernel.GetType().FullName}, but CudaKernelExecutor requires a CUDA-compiled kernel. The kernel was compiled for a different backend or is a wrapper that cannot be converted — compile it through CudaKernelCompiler / IUnifiedKernelCompiler targeting the CUDA accelerator.",
+                nameof(kernel));
 
             // Set CUDA context
             _context.MakeCurrent();

--- a/src/Backends/DotCompute.Backends.CUDA/Execution/CudaStreamManager.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/Execution/CudaStreamManager.cs
@@ -44,8 +44,12 @@ namespace DotCompute.Backends.CUDA.Execution
 
         public CudaStreamManager(CudaContext context, ILogger<CudaStreamManager> logger)
         {
-            _context = context ?? throw new ArgumentNullException(nameof(context));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _context = context ?? throw new ArgumentNullException(
+                nameof(context),
+                "CudaContext is required for CudaStreamManager. Obtain it from CudaAccelerator.Context — streams are context-bound resources.");
+            _logger = logger ?? throw new ArgumentNullException(
+                nameof(logger),
+                "ILogger<CudaStreamManager> is required. Register logging via AddLogging() so stream lifecycle and dependency events are captured.");
             _activeStreams = new ConcurrentDictionary<StreamId, CudaStreamInfo>();
             _streamGroups = new ConcurrentDictionary<string, CudaStreamGroup>();
             _streamCreationSemaphore = new SemaphoreSlim(MAX_CONCURRENT_STREAMS, MAX_CONCURRENT_STREAMS);
@@ -223,7 +227,9 @@ namespace DotCompute.Backends.CUDA.Execution
 
             if (!_activeStreams.TryGetValue(streamId, out var streamInfo))
             {
-                throw new ArgumentException($"Stream {streamId} not found", nameof(streamId));
+                throw new ArgumentException(
+                    $"CudaStreamManager has no active stream with id {streamId}. The stream was never created, or was destroyed via DestroyStream. Call CreateStream(...) before using.",
+                    nameof(streamId));
             }
 
             _context.MakeCurrent();
@@ -244,7 +250,8 @@ namespace DotCompute.Backends.CUDA.Execution
                 }
                 catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
                 {
-                    throw new TimeoutException($"Stream {streamId} synchronization timed out after {timeout}");
+                    throw new TimeoutException(
+                        $"cudaStreamSynchronize({streamId}) timed out after {timeout}. Work queued on the stream has not completed within the deadline — inspect kernel/memcpy progress via NSight Compute, reduce queue depth, or raise the timeout.");
                 }
             }
             else
@@ -272,12 +279,16 @@ namespace DotCompute.Backends.CUDA.Execution
 
             if (!_activeStreams.TryGetValue(waitingStream, out var waitingStreamInfo))
             {
-                throw new ArgumentException($"Waiting stream {waitingStream} not found");
+                throw new ArgumentException(
+                    $"Waiting stream {waitingStream} is not active in CudaStreamManager. Inter-stream synchronization requires both streams to be created and alive.",
+                    nameof(waitingStream));
             }
 
             if (!_activeStreams.TryGetValue(signalStream, out var signalStreamInfo))
             {
-                throw new ArgumentException($"Signal stream {signalStream} not found");
+                throw new ArgumentException(
+                    $"Signal stream {signalStream} is not active in CudaStreamManager. Inter-stream synchronization requires both streams to be created and alive.",
+                    nameof(signalStream));
             }
 
             _context.MakeCurrent();
@@ -419,7 +430,9 @@ namespace DotCompute.Backends.CUDA.Execution
 
             if (!_activeStreams.TryGetValue(streamId, out var streamInfo))
             {
-                throw new ArgumentException($"Stream {streamId} not found");
+                throw new ArgumentException(
+                    $"Cannot add callback: stream {streamId} is not active in CudaStreamManager. Create the stream before registering completion callbacks.",
+                    nameof(streamId));
             }
 
             _ = Task.Run(async () =>

--- a/src/Backends/DotCompute.Backends.CUDA/Execution/CudaTensorCoreManager.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/Execution/CudaTensorCoreManager.cs
@@ -141,7 +141,8 @@ namespace DotCompute.Backends.CUDA.Advanced
 
             if (!IsSupported)
             {
-                throw new NotSupportedException("Tensor Cores not supported on this device");
+                throw new NotSupportedException(
+                    $"Tensor Cores are not supported on this CUDA device. Tensor Cores require Volta (CC 7.0), Turing (CC 7.5), Ampere (CC 8.0/8.6), Ada (CC 8.9), or Hopper (CC 9.0+). Query IsSupported before calling Tensor Core operations, or run on a newer GPU.");
             }
 
             var startTime = DateTimeOffset.UtcNow;
@@ -189,13 +190,17 @@ namespace DotCompute.Backends.CUDA.Advanced
         {
             if (!IsSupported)
             {
-                throw new NotSupportedException("Tensor Cores not supported");
+                throw new NotSupportedException(
+                    "Tensor Cores are not supported on this CUDA device. Optimized GEMM paths require Volta CC 7.0 or newer — query IsSupported first, or fall back to cuBLAS SGEMM on older hardware.");
             }
 
             // Validate matrix dimensions for Tensor Core compatibility
             if (!ValidateGEMMDimensions(gemmOp))
             {
-                throw new ArgumentException("Matrix dimensions not compatible with Tensor Cores", nameof(gemmOp));
+                throw new ArgumentException(
+                    $"Matrix dimensions M={gemmOp.M}, N={gemmOp.N}, K={gemmOp.K} (precision={gemmOp.Precision}) are not compatible with Tensor Core alignment requirements. " +
+                    $"Tensor Cores require M, N, K to be multiples of the tile size (typically 8 for FP16, 16 for INT8). Pad dimensions to the next multiple or fall back to a non-TC GEMM path.",
+                    nameof(gemmOp));
             }
 
             var operation = new CudaTensorOperation

--- a/src/Backends/DotCompute.Backends.CUDA/Execution/CudaTensorCoreManagerProduction.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/Execution/CudaTensorCoreManagerProduction.cs
@@ -236,7 +236,11 @@ public sealed partial class CudaTensorCoreManagerProduction : IDisposable
 
         if (!supported)
         {
-            throw new NotSupportedException($"Data type {inputType} is not supported by tensor cores on this device");
+            throw new NotSupportedException(
+                $"Tensor Core data type {inputType} is not supported on this CUDA device. Supported types on this device: " +
+                $"FP16={_capabilities.Fp16Supported}, BF16={_capabilities.Bf16Supported}, TF32={_capabilities.Tf32Supported}, " +
+                $"FP8={_capabilities.Fp8Supported}, INT8={_capabilities.Int8Supported}, INT4={_capabilities.Int4Supported}, FP64={_capabilities.Fp64Supported}. " +
+                "Choose a supported type or upgrade the GPU (Hopper CC 9.0 for FP8, Ampere CC 8.0 for BF16/TF32).");
         }
     }
 

--- a/src/Backends/DotCompute.Backends.CUDA/Execution/Graph/CudaGraph.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/Execution/Graph/CudaGraph.cs
@@ -45,7 +45,9 @@ namespace DotCompute.Backends.CUDA.Execution.Graph
             if (string.IsNullOrWhiteSpace(name))
             {
 
-                throw new ArgumentException("Graph name cannot be null or empty.", nameof(name));
+                throw new ArgumentException(
+                    $"CudaGraph requires a non-empty human-readable name (received '{name ?? "<null>"}'). The name identifies the graph in logs, metrics, and cross-references to instances.",
+                    nameof(name));
             }
 
 
@@ -180,7 +182,8 @@ namespace DotCompute.Backends.CUDA.Execution.Graph
                 // Check for duplicate node IDs
                 if (_nodes.Any(n => n.Id == node.Id))
                 {
-                    throw new InvalidOperationException($"A node with ID '{node.Id}' already exists in the graph.");
+                    throw new InvalidOperationException(
+                        $"Duplicate CudaGraphNode id '{node.Id}' — graph '{Name}' already contains a node with this id. Node ids must be unique within a graph; use Guid.NewGuid() or a type-prefixed naming scheme if you construct ids manually.");
                 }
 
                 _nodes.Add(node);
@@ -204,7 +207,9 @@ namespace DotCompute.Backends.CUDA.Execution.Graph
             if (string.IsNullOrWhiteSpace(nodeId))
             {
 
-                throw new ArgumentException("Node ID cannot be null or empty.", nameof(nodeId));
+                throw new ArgumentException(
+                    $"CudaGraphNode id must be a non-empty string (received '{nodeId ?? "<null>"}'). Use the id returned by AddNode or the key you used when constructing the node.",
+                    nameof(nodeId));
             }
 
 
@@ -260,7 +265,9 @@ namespace DotCompute.Backends.CUDA.Execution.Graph
             if (string.IsNullOrWhiteSpace(nodeId))
             {
 
-                throw new ArgumentException("Node ID cannot be null or empty.", nameof(nodeId));
+                throw new ArgumentException(
+                    $"CudaGraphNode id must be a non-empty string (received '{nodeId ?? "<null>"}'). Use the id returned by AddNode or the key you used when constructing the node.",
+                    nameof(nodeId));
             }
 
 

--- a/src/Backends/DotCompute.Backends.CUDA/Execution/Graph/CudaGraphManager.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/Execution/Graph/CudaGraphManager.cs
@@ -35,7 +35,9 @@ namespace DotCompute.Backends.CUDA.Execution.Graph
         [SuppressMessage("Performance", "CA1823:Avoid unused private fields",
             Justification = "Reserved for future use - will be used for context-specific graph operations")]
         private readonly CudaContext _context = context; // Reserved for future use
-        private readonly ILogger<CudaGraphManager> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        private readonly ILogger<CudaGraphManager> _logger = logger ?? throw new ArgumentNullException(
+            nameof(logger),
+            "ILogger<CudaGraphManager> is required. Register logging via AddLogging() so graph capture/instantiate/launch events are captured.");
         private readonly ConcurrentDictionary<string, CudaGraph> _graphs = new();
         private readonly ConcurrentDictionary<string, CudaGraphExecutable> _executables = new();
         private readonly ConcurrentDictionary<string, Types.GraphStatistics> _statistics = new();
@@ -52,7 +54,8 @@ namespace DotCompute.Backends.CUDA.Execution.Graph
 
             if (_graphs.ContainsKey(name))
             {
-                throw new InvalidOperationException($"Graph '{name}' already exists");
+                throw new InvalidOperationException(
+                    $"CUDA graph '{name}' is already registered in CudaGraphManager. Existing graphs: [{string.Join(", ", _graphs.Keys)}]. Use GetGraph(\"{name}\") to retrieve it, or choose a distinct name.");
             }
 
             var graph = new CudaGraph
@@ -460,7 +463,8 @@ namespace DotCompute.Backends.CUDA.Execution.Graph
 
             if (_executables.ContainsKey(graph.Name))
             {
-                throw new InvalidOperationException($"Graph '{graph.Name}' is already instantiated");
+                throw new InvalidOperationException(
+                    $"CUDA graph '{graph.Name}' has already been instantiated in this manager. Each graph can have one CudaGraphExecutable at a time — release the existing executable via DestroyExecutable(\"{graph.Name}\") before re-instantiating, or modify the graph and call UpdateExecutable.");
             }
 
             var execHandle = IntPtr.Zero;
@@ -479,7 +483,10 @@ namespace DotCompute.Backends.CUDA.Execution.Graph
                 if (result != CudaError.Success)
                 {
                     var log = Marshal.PtrToStringAnsi(logBuffer) ?? "No error details";
-                    throw new CudaException($"Failed to instantiate graph: {log}", result);
+                    throw new CudaException(
+                        $"cudaGraphInstantiate for graph '{graph.Name}' failed: {result} ({(int)result}). Driver log: {log}. " +
+                        $"Common causes: invalid node dependencies, unsupported node types, or device-side errors during capture. Review node definitions and run compute-sanitizer on the capture path.",
+                        result);
                 }
 
                 var executable = new CudaGraphExecutable
@@ -627,7 +634,8 @@ namespace DotCompute.Backends.CUDA.Execution.Graph
 
             if (_graphs.ContainsKey(newName))
             {
-                throw new InvalidOperationException($"Graph '{newName}' already exists");
+                throw new InvalidOperationException(
+                    $"Cannot clone into target name '{newName}': a graph with that name is already registered in CudaGraphManager. Remove the existing graph first or choose a distinct clone name.");
             }
 
             var result = CudaRuntime.cuGraphClone(out var cloneHandle, sourceGraph.Handle);

--- a/src/Backends/DotCompute.Backends.CUDA/RingKernels/CudaMessageQueue.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/RingKernels/CudaMessageQueue.cs
@@ -102,10 +102,14 @@ public sealed class CudaMessageQueue<T> : IMessageQueue<T> where T : unmanaged
     {
         if (capacity <= 0 || (capacity & (capacity - 1)) != 0)
         {
-            throw new ArgumentException("Capacity must be a positive power of 2", nameof(capacity));
+            throw new ArgumentException(
+                $"CudaMessageQueue<{typeof(T).Name}> capacity must be a positive power of 2 (received {capacity}). The SPMC ring uses bitwise index masking — try 64, 128, 256, 512, 1024 …",
+                nameof(capacity));
         }
 
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _logger = logger ?? throw new ArgumentNullException(
+            nameof(logger),
+            $"ILogger<CudaMessageQueue<{typeof(T).Name}>> is required — used for initialization and lifecycle diagnostics. Register logging via AddLogging() or pass NullLogger for tests.");
         _capacity = capacity;
         Capacity = capacity;
     }
@@ -115,7 +119,8 @@ public sealed class CudaMessageQueue<T> : IMessageQueue<T> where T : unmanaged
     {
         if (!_initialized)
         {
-            throw new InvalidOperationException("Queue not initialized. Call InitializeAsync first.");
+            throw new InvalidOperationException(
+                $"CudaMessageQueue<{typeof(T).Name}> (capacity={_capacity}) has not been initialized. Call InitializeAsync(cancellationToken) once at startup before accessing device buffers or head/tail pointers.");
         }
 
         var messageSize = Unsafe.SizeOf<KernelMessage<T>>();
@@ -128,7 +133,8 @@ public sealed class CudaMessageQueue<T> : IMessageQueue<T> where T : unmanaged
     {
         if (!_initialized)
         {
-            throw new InvalidOperationException("Queue not initialized. Call InitializeAsync first.");
+            throw new InvalidOperationException(
+                $"CudaMessageQueue<{typeof(T).Name}> (capacity={_capacity}) has not been initialized. Call InitializeAsync(cancellationToken) once at startup before accessing device buffers or head/tail pointers.");
         }
 
         return new CudaDevicePointerBuffer(_deviceHead, sizeof(int), MemoryOptions.None);
@@ -139,7 +145,8 @@ public sealed class CudaMessageQueue<T> : IMessageQueue<T> where T : unmanaged
     {
         if (!_initialized)
         {
-            throw new InvalidOperationException("Queue not initialized. Call InitializeAsync first.");
+            throw new InvalidOperationException(
+                $"CudaMessageQueue<{typeof(T).Name}> (capacity={_capacity}) has not been initialized. Call InitializeAsync(cancellationToken) once at startup before accessing device buffers or head/tail pointers.");
         }
 
         return new CudaDevicePointerBuffer(_deviceTail, sizeof(int), MemoryOptions.None);
@@ -166,14 +173,17 @@ public sealed class CudaMessageQueue<T> : IMessageQueue<T> where T : unmanaged
             var initResult = cuInit(0);
             if (initResult is not CudaError.Success and not ((CudaError)4)) // 4 = CUDA_ERROR_ALREADY_INITIALIZED
             {
-                throw new InvalidOperationException($"Failed to initialize CUDA Driver API: {initResult}");
+                throw new InvalidOperationException(
+                    $"cuInit(0) failed while initializing CudaMessageQueue<{typeof(T).Name}>: {initResult} ({(int)initResult}). " +
+                    $"Verify NVIDIA driver is installed, CUDA toolkit matches the driver version, and (on WSL2) LD_LIBRARY_PATH includes /usr/lib/wsl/lib.");
             }
 
             // Get device handle for device 0
             var getDeviceResult = CudaRuntime.cuDeviceGet(out var device, 0);
             if (getDeviceResult != CudaError.Success)
             {
-                throw new InvalidOperationException($"Failed to get CUDA device: {getDeviceResult}");
+                throw new InvalidOperationException(
+                    $"cuDeviceGet(0) failed while initializing CudaMessageQueue<{typeof(T).Name}>: {getDeviceResult} ({(int)getDeviceResult}). No GPU at device ordinal 0 — verify nvidia-smi sees a device and CUDA_VISIBLE_DEVICES is not restricting it.");
             }
 
             // Initialize Runtime API first (activates primary context)
@@ -188,7 +198,8 @@ public sealed class CudaMessageQueue<T> : IMessageQueue<T> where T : unmanaged
             var ctxResult = CudaRuntime.cuDevicePrimaryCtxRetain(ref _context, device);
             if (ctxResult != CudaError.Success)
             {
-                throw new InvalidOperationException($"Failed to retain primary CUDA context: {ctxResult}");
+                throw new InvalidOperationException(
+                    $"cuDevicePrimaryCtxRetain(device={device}) failed for CudaMessageQueue<{typeof(T).Name}>: {ctxResult} ({(int)ctxResult}). The device is likely in exclusive-process mode held by another process, or in a fatal error state.");
             }
 
             _deviceId = device;  // Store for cleanup
@@ -199,7 +210,8 @@ public sealed class CudaMessageQueue<T> : IMessageQueue<T> where T : unmanaged
             {
                 CudaRuntime.cuDevicePrimaryCtxRelease(device);
                 _deviceId = -1;
-                throw new InvalidOperationException($"Failed to set primary context as current: {setCtxResult}");
+                throw new InvalidOperationException(
+                    $"cuCtxSetCurrent(primary) failed for CudaMessageQueue<{typeof(T).Name}> (device={device}): {setCtxResult} ({(int)setCtxResult}). Context was released during cleanup. Possibly another thread released the primary context — review lifecycle ordering.");
             }
 
             // Calculate sizes - use Unsafe.SizeOf for generic types
@@ -283,7 +295,8 @@ public sealed class CudaMessageQueue<T> : IMessageQueue<T> where T : unmanaged
     {
         if (!_initialized)
         {
-            throw new InvalidOperationException("Queue not initialized");
+            throw new InvalidOperationException(
+                $"CudaMessageQueue<{typeof(T).Name}> (capacity={_capacity}) has not been initialized — call InitializeAsync before enqueue/dequeue.");
         }
 
         return await Task.Run(() =>
@@ -369,7 +382,8 @@ public sealed class CudaMessageQueue<T> : IMessageQueue<T> where T : unmanaged
     {
         if (!_initialized)
         {
-            throw new InvalidOperationException("Queue not initialized");
+            throw new InvalidOperationException(
+                $"CudaMessageQueue<{typeof(T).Name}> (capacity={_capacity}) has not been initialized — call InitializeAsync before enqueue/dequeue.");
         }
 
         return await Task.Run(() =>
@@ -471,7 +485,8 @@ public sealed class CudaMessageQueue<T> : IMessageQueue<T> where T : unmanaged
 
             if (DateTime.UtcNow >= deadline)
             {
-                throw new TimeoutException("Failed to enqueue message within timeout period");
+                throw new TimeoutException(
+                    $"CudaMessageQueue<{typeof(T).Name}>.EnqueueAsync timed out after {timeout} waiting for a free slot (queue capacity={_capacity}). The GPU consumer may be stalled, or producers may be exceeding consumer throughput. Check kernel progress via GetStatusAsync or raise capacity.");
             }
 
             await Task.Delay(1, cancellationToken);
@@ -497,7 +512,8 @@ public sealed class CudaMessageQueue<T> : IMessageQueue<T> where T : unmanaged
 
             if (DateTime.UtcNow >= deadline)
             {
-                throw new TimeoutException("Failed to dequeue message within timeout period");
+                throw new TimeoutException(
+                    $"CudaMessageQueue<{typeof(T).Name}>.DequeueAsync timed out after {timeout} waiting for a message (queue capacity={_capacity}). No producer published a message within the deadline — check that the kernel/producer is active and emitting output.");
             }
 
             await Task.Delay(1, cancellationToken);

--- a/src/Backends/DotCompute.Backends.CUDA/RingKernels/CudaRingKernelRuntime.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/RingKernels/CudaRingKernelRuntime.cs
@@ -96,9 +96,15 @@ public sealed partial class CudaRingKernelRuntime : IRingKernelRuntime
         MessageQueueRegistry registry,
         RingKernelFaultRecoveryOptions? faultRecoveryOptions = null)
     {
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _compiler = compiler ?? throw new ArgumentNullException(nameof(compiler));
-        _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+        _logger = logger ?? throw new ArgumentNullException(
+            nameof(logger),
+            "ILogger<CudaRingKernelRuntime> is required. Register logging via AddLogging() so ring-kernel lifecycle and fault-recovery events are visible.");
+        _compiler = compiler ?? throw new ArgumentNullException(
+            nameof(compiler),
+            "CudaRingKernelCompiler is required — it produces PTX/cubin for the ring kernels. Obtain it from the DI container (AddDotComputeCuda() registers it).");
+        _registry = registry ?? throw new ArgumentNullException(
+            nameof(registry),
+            "MessageQueueRegistry is required for named-queue resolution across ring kernels. Register it via AddDotComputeCuda() or construct a singleton instance manually.");
         _faultRecoveryOptions = faultRecoveryOptions ?? RingKernelFaultRecoveryOptions.Default;
 
         // Create watchdog if enabled
@@ -196,7 +202,10 @@ public sealed partial class CudaRingKernelRuntime : IRingKernelRuntime
                 var initResult = CudaRuntimeCore.cuInit(0);
                 if (initResult is not CudaError.Success and not ((CudaError)4))
                 {
-                    throw new InvalidOperationException($"Failed to initialize CUDA: {initResult}");
+                    throw new InvalidOperationException(
+                        $"CUDA Driver API initialization failed (cuInit): {initResult} ({(int)initResult}). " +
+                        $"Possible causes: no NVIDIA driver installed, driver/Toolkit version mismatch, GPU not visible (check nvidia-smi), or WSL2 library path issue. " +
+                        $"On WSL2 ensure LD_LIBRARY_PATH includes /usr/lib/wsl/lib before starting the process.");
                 }
 
                 // Use primary context for better compatibility with CUDA linker API
@@ -213,7 +222,9 @@ public sealed partial class CudaRingKernelRuntime : IRingKernelRuntime
                     var getDeviceResult = CudaRuntime.cuDeviceGet(out var device, 0);
                     if (getDeviceResult != CudaError.Success)
                     {
-                        throw new InvalidOperationException($"Failed to get CUDA device: {getDeviceResult}");
+                        throw new InvalidOperationException(
+                            $"cuDeviceGet(0) failed: {getDeviceResult} ({(int)getDeviceResult}). " +
+                            $"The CUDA runtime reports no device at ordinal 0. Run nvidia-smi to verify a GPU is visible, check CUDA_VISIBLE_DEVICES, and ensure the process has permission to access /dev/nvidia*.");
                     }
 
                     // Initialize Runtime API first - this activates the primary context
@@ -228,7 +239,9 @@ public sealed partial class CudaRingKernelRuntime : IRingKernelRuntime
                     var ctxResult = CudaRuntime.cuDevicePrimaryCtxRetain(ref _sharedContext, device);
                     if (ctxResult != CudaError.Success)
                     {
-                        throw new InvalidOperationException($"Failed to retain primary CUDA context: {ctxResult}");
+                        throw new InvalidOperationException(
+                            $"cuDevicePrimaryCtxRetain(device={device}) failed: {ctxResult} ({(int)ctxResult}). " +
+                            $"The primary context cannot be retained — this usually indicates the device is busy, in an exclusive-process mode owned by another process, or in a fatal error state. Run `nvidia-smi -q -d COMPUTE` to inspect compute mode.");
                     }
 
                     _sharedDevice = device;  // Store for release
@@ -241,7 +254,9 @@ public sealed partial class CudaRingKernelRuntime : IRingKernelRuntime
                         CudaRuntime.cuDevicePrimaryCtxRelease(device);
                         _sharedContext = IntPtr.Zero;
                         _sharedDevice = -1;
-                        throw new InvalidOperationException($"Failed to set primary context as current: {setCtxResult}");
+                        throw new InvalidOperationException(
+                            $"cuCtxSetCurrent(primary context=0x{_sharedContext.ToInt64():X}) failed for device {device}: {setCtxResult} ({(int)setCtxResult}). " +
+                            $"The primary context was released after this failure. This usually indicates driver-level corruption or GPU fallen off the bus — try resetting the device (nvidia-smi -r) or rebooting.");
                     }
 
                     _logger.LogDebug("Retained primary CUDA context: 0x{Context:X} for device {Device}", _sharedContext.ToInt64(), device);
@@ -473,14 +488,15 @@ public sealed partial class CudaRingKernelRuntime : IRingKernelRuntime
 
         if (gridSize <= 0 || blockSize <= 0)
         {
-            throw new ArgumentException("Grid and block sizes must be positive");
+            throw new ArgumentException(
+                $"Ring kernel launch '{kernelId}' requires positive grid and block sizes (got gridSize={gridSize}, blockSize={blockSize}). Typical values: gridSize = ceil(problemSize/blockSize), blockSize = 128 or 256. Zero/negative dimensions are invalid CUDA launch configurations.");
         }
 
         // Check if kernel is already launched
         if (_kernels.ContainsKey(kernelId))
         {
             throw new InvalidOperationException(
-                $"Kernel '{kernelId}' is already launched. Terminate it before launching again.");
+                $"Ring kernel '{kernelId}' is already launched and active. Each kernel id can have only one live instance at a time — call TerminateAsync(kernelId) first, or use a distinct id for a parallel launch.");
         }
 
         // Ensure options is not null
@@ -575,7 +591,8 @@ public sealed partial class CudaRingKernelRuntime : IRingKernelRuntime
 
                     if (createQueueMethod == null)
                     {
-                        throw new InvalidOperationException($"Failed to find CreateMessageQueueAsync method via reflection");
+                        throw new InvalidOperationException(
+                            $"CudaRingKernelRuntime.CreateMessageQueueAsync method was not found via reflection on {typeof(CudaRingKernelRuntime).FullName}. This is an internal invariant — likely a trimming/AOT removal. Ensure RingKernels assembly is not aggressively trimmed, or avoid AOT for ring-kernel scenarios.");
                     }
 
                     var genericMethod = createQueueMethod.MakeGenericMethod(inputType);
@@ -583,7 +600,8 @@ public sealed partial class CudaRingKernelRuntime : IRingKernelRuntime
 
                     if (queueTask == null)
                     {
-                        throw new InvalidOperationException($"Failed to invoke CreateMessageQueueAsync for type {inputType.Name}");
+                        throw new InvalidOperationException(
+                            $"CreateMessageQueueAsync<{inputType.Name}> returned null via reflection while initializing ring kernel '{kernelId}' input queue (capacity={options.QueueCapacity}). This indicates the method signature changed or the generic instantiation failed — report as a bug if the underlying type is unchanged.");
                     }
 
                     await queueTask;
@@ -591,7 +609,8 @@ public sealed partial class CudaRingKernelRuntime : IRingKernelRuntime
                     var resultProperty = queueTask.GetType().GetProperty("Result");
                     if (resultProperty == null)
                     {
-                        throw new InvalidOperationException($"Failed to get Result property from Task");
+                        throw new InvalidOperationException(
+                            $"Could not reflect the Task.Result property while reading the message-queue creation result for ring kernel '{kernelId}'. The reflection path assumes a Task<T> was returned — report as a bug if you see this consistently.");
                     }
 
                     state.InputQueue = resultProperty.GetValue(queueTask);
@@ -645,7 +664,8 @@ public sealed partial class CudaRingKernelRuntime : IRingKernelRuntime
 
                     if (createQueueMethod == null)
                     {
-                        throw new InvalidOperationException($"Failed to find CreateMessageQueueAsync method via reflection");
+                        throw new InvalidOperationException(
+                            $"CudaRingKernelRuntime.CreateMessageQueueAsync method was not found via reflection on {typeof(CudaRingKernelRuntime).FullName}. This is an internal invariant — likely a trimming/AOT removal. Ensure RingKernels assembly is not aggressively trimmed, or avoid AOT for ring-kernel scenarios.");
                     }
 
                     var genericMethod = createQueueMethod.MakeGenericMethod(outputType);
@@ -653,7 +673,8 @@ public sealed partial class CudaRingKernelRuntime : IRingKernelRuntime
 
                     if (queueTask == null)
                     {
-                        throw new InvalidOperationException($"Failed to invoke CreateMessageQueueAsync for type {outputType.Name}");
+                        throw new InvalidOperationException(
+                            $"CreateMessageQueueAsync<{outputType.Name}> returned null via reflection while initializing ring kernel '{kernelId}' output queue (capacity={options.QueueCapacity}). This indicates the method signature changed or the generic instantiation failed — report as a bug if the underlying type is unchanged.");
                     }
 
                     await queueTask;
@@ -661,7 +682,8 @@ public sealed partial class CudaRingKernelRuntime : IRingKernelRuntime
                     var resultProperty = queueTask.GetType().GetProperty("Result");
                     if (resultProperty == null)
                     {
-                        throw new InvalidOperationException($"Failed to get Result property from Task");
+                        throw new InvalidOperationException(
+                            $"Could not reflect the Task.Result property while reading the message-queue creation result for ring kernel '{kernelId}'. The reflection path assumes a Task<T> was returned — report as a bug if you see this consistently.");
                     }
 
                     state.OutputQueue = resultProperty.GetValue(queueTask);
@@ -690,7 +712,8 @@ public sealed partial class CudaRingKernelRuntime : IRingKernelRuntime
                         : $" {registeredCount} assemblies registered.";
                     throw new InvalidOperationException(
                         $"Failed to compile ring kernel '{kernelId}'.{hint} " +
-                        "Ensure the [RingKernel] method exists and has a corresponding message handler.");
+                        "Ensure the [RingKernel]-attributed method exists in one of the registered assemblies and declares a matching message handler signature. " +
+                        "Enable debug-level logging on CudaRingKernelCompiler to see the exact stage (discovery → codegen → PTX → module load) that failed.");
                 }
 
                 // CRITICAL: Restore CUDA context after compilation
@@ -770,7 +793,9 @@ public sealed partial class CudaRingKernelRuntime : IRingKernelRuntime
                 // For direct GPU queues (CudaMessageQueue), use queue head/tail pointers
                 if (state.InputQueue == null || state.OutputQueue == null)
                 {
-                    throw new InvalidOperationException("Input and output queues must be initialized before accessing control block");
+                    throw new InvalidOperationException(
+                        $"Ring kernel '{kernelId}' has null InputQueue or OutputQueue at control-block initialization (InputQueue={(state.InputQueue == null ? "null" : "ok")}, OutputQueue={(state.OutputQueue == null ? "null" : "ok")}). " +
+                        $"Both queues must be created in Step 2 of LaunchAsync before the control block is populated — this indicates an ordering bug in the launch pipeline.");
                 }
 
                 // CRITICAL: Start kernel active in EventDriven mode.
@@ -884,7 +909,8 @@ public sealed partial class CudaRingKernelRuntime : IRingKernelRuntime
                 if (streamResult != CudaError.Success)
                 {
                     throw new InvalidOperationException(
-                        $"Failed to create CUDA stream with priority {options.StreamPriority}: {streamResult}");
+                        $"cuStreamCreateWithPriority for ring kernel '{kernelId}' (priority={options.StreamPriority}, cudaPriority={cudaPriority}) failed: {streamResult} ({(int)streamResult}). " +
+                        $"Possible causes: exceeded per-device stream limit, invalid priority value (query valid range via cuCtxGetStreamPriorityRange), or context corruption. Reduce concurrent stream usage or use default priority.");
                 }
                 state.Stream = stream;
 
@@ -909,21 +935,25 @@ public sealed partial class CudaRingKernelRuntime : IRingKernelRuntime
                 var getDevResult = CudaRuntimeCore.cuCtxGetDevice(out var deviceId);
                 if (getDevResult != CudaError.Success)
                 {
-                    throw new InvalidOperationException($"Failed to get current device: {getDevResult}");
+                    throw new InvalidOperationException(
+                        $"cuCtxGetDevice failed while validating cooperative-kernel support for ring kernel '{kernelId}': {getDevResult} ({(int)getDevResult}). " +
+                        $"The current CUDA context appears invalid — ensure a context is attached to the calling thread and the device is not in a fatal error state.");
                 }
 
                 CudaDeviceProperties deviceProps = default;
                 var getPropResult = CudaRuntime.cudaGetDeviceProperties(ref deviceProps, deviceId);
                 if (getPropResult != CudaError.Success)
                 {
-                    throw new InvalidOperationException($"Failed to get device properties: {getPropResult}");
+                    throw new InvalidOperationException(
+                        $"cudaGetDeviceProperties(device={deviceId}) failed while validating ring kernel '{kernelId}': {getPropResult} ({(int)getPropResult}). Cannot determine compute-capability support — check the device is healthy via nvidia-smi.");
                 }
 
                 // Check compute capability (cooperative kernels require 6.0+)
                 if (deviceProps.Major < 6)
                 {
                     throw new NotSupportedException(
-                        $"Cooperative kernel launches require compute capability 6.0+, but device has {deviceProps.Major}.{deviceProps.Minor}");
+                        $"Ring kernel '{kernelId}' requires cooperative-launch support (compute capability 6.0+), but device '{deviceProps.DeviceName}' reports CC {deviceProps.Major}.{deviceProps.Minor}. " +
+                        $"Use a newer GPU (Pascal/Volta/Turing/Ampere/Ada/Hopper) or run on a device with CC 6.0 or higher. Query device capability via CudaCapabilityManager.GetTargetComputeCapability().");
                 }
 
                 _logger.LogDebug(
@@ -939,7 +969,9 @@ public sealed partial class CudaRingKernelRuntime : IRingKernelRuntime
                 var setCtxResult = CudaRuntimeCore.cuCtxSetCurrent(state.Context);
                 if (setCtxResult != CudaError.Success)
                 {
-                    throw new InvalidOperationException($"Failed to set CUDA context: {setCtxResult}");
+                    throw new InvalidOperationException(
+                        $"cuCtxSetCurrent(context=0x{state.Context.ToInt64():X}) failed before launching ring kernel '{kernelId}': {setCtxResult} ({(int)setCtxResult}). " +
+                        $"The per-kernel context cannot be made current on this thread — likely another thread released it, or the GPU is in an error state. Call cuCtxGetApiVersion(...) to probe context health.");
                 }
 
                 // Marshal kernel parameters: single pointer to the control block
@@ -981,7 +1013,9 @@ public sealed partial class CudaRingKernelRuntime : IRingKernelRuntime
                         if (launchResult != CudaError.Success)
                         {
                             throw new InvalidOperationException(
-                                $"Failed to launch cooperative kernel '{kernelId}': {launchResult}");
+                                $"cuLaunchCooperativeKernel for ring kernel '{kernelId}' failed: {launchResult} ({(int)launchResult}). " +
+                                $"Grid={gridSize}, Block={blockSize}, Stream=0x{state.Stream.ToInt64():X}, Function=0x{state.Function.ToInt64():X}. " +
+                                $"Common causes: grid/block exceeds cooperative launch limits (query MaxCooperativeBlocksPerMultiprocessor), device in error state, or shared-memory overflow. Run with compute-sanitizer for details.");
                         }
 
                         // CRITICAL: Do NOT synchronize stream for either EventDriven or Persistent mode.
@@ -1066,12 +1100,14 @@ public sealed partial class CudaRingKernelRuntime : IRingKernelRuntime
 
         if (!_kernels.TryGetValue(kernelId, out var state))
         {
-            throw new InvalidOperationException($"Kernel '{kernelId}' not found");
+            throw new InvalidOperationException(
+                $"Ring kernel '{kernelId}' was not found in the runtime. Currently registered kernels: [{string.Join(", ", _kernels.Keys)}]. Call LaunchAsync(kernelId, ...) before Activate/Deactivate/Terminate.");
         }
 
         if (!state.IsLaunched)
         {
-            throw new InvalidOperationException($"Kernel '{kernelId}' not launched");
+            throw new InvalidOperationException(
+                $"Ring kernel '{kernelId}' exists but is not yet launched (IsLaunched=false). This indicates a partial-launch state — the kernel was registered but cuLaunchCooperativeKernel failed. Call TerminateAsync to clean up and retry LaunchAsync.");
         }
 
         if (state.IsActive)
@@ -1109,12 +1145,14 @@ public sealed partial class CudaRingKernelRuntime : IRingKernelRuntime
 
         if (!_kernels.TryGetValue(kernelId, out var state))
         {
-            throw new InvalidOperationException($"Kernel '{kernelId}' not found");
+            throw new InvalidOperationException(
+                $"Ring kernel '{kernelId}' was not found in the runtime. Currently registered kernels: [{string.Join(", ", _kernels.Keys)}]. Call LaunchAsync(kernelId, ...) before DeactivateAsync.");
         }
 
         if (!state.IsActive)
         {
-            throw new InvalidOperationException($"Kernel '{kernelId}' not active");
+            throw new InvalidOperationException(
+                $"Ring kernel '{kernelId}' is not currently active — DeactivateAsync is a no-op in this state. Call ActivateAsync first, or check IsActive on the state before deactivating.");
         }
 
         _logger.LogInformation("Deactivating ring kernel '{KernelId}'", kernelId);
@@ -1145,7 +1183,8 @@ public sealed partial class CudaRingKernelRuntime : IRingKernelRuntime
 
         if (!_kernels.TryGetValue(kernelId, out var state))
         {
-            throw new InvalidOperationException($"Kernel '{kernelId}' not found");
+            throw new InvalidOperationException(
+                $"Ring kernel '{kernelId}' was not found in the runtime. Currently registered kernels: [{string.Join(", ", _kernels.Keys)}]. TerminateAsync is a no-op for unknown kernels — verify the id or ensure LaunchAsync completed successfully.");
         }
 
         _logger.LogInformation("Terminating ring kernel '{KernelId}'", kernelId);
@@ -1339,12 +1378,16 @@ public sealed partial class CudaRingKernelRuntime : IRingKernelRuntime
 
         if (!_kernels.TryGetValue(kernelId, out var state))
         {
-            throw new ArgumentException($"Kernel '{kernelId}' not found", nameof(kernelId));
+            throw new ArgumentException(
+                $"Ring kernel '{kernelId}' is not registered with CudaRingKernelRuntime. Active kernels: [{string.Join(", ", _kernels.Keys)}]. Call LaunchAsync(kernelId, gridSize, blockSize) before accessing the kernel.",
+                nameof(kernelId));
         }
 
         if (state.InputQueue is not DotCompute.Abstractions.RingKernels.IMessageQueue<T> queue)
         {
-            throw new InvalidOperationException($"Input queue not available for kernel '{kernelId}'");
+            throw new InvalidOperationException(
+                $"Input queue for ring kernel '{kernelId}' is not an IMessageQueue<{typeof(T).Name}> — actual type: {state.InputQueue?.GetType().Name ?? "null"}. " +
+                $"This kernel was launched with a different message type. SendMessageAsync<T> must match the type declared by the kernel's [RingKernel] input signature.");
         }
 
         await queue.EnqueueAsync(message, default, cancellationToken);
@@ -1361,12 +1404,16 @@ public sealed partial class CudaRingKernelRuntime : IRingKernelRuntime
 
         if (!_kernels.TryGetValue(kernelId, out var state))
         {
-            throw new ArgumentException($"Kernel '{kernelId}' not found", nameof(kernelId));
+            throw new ArgumentException(
+                $"Ring kernel '{kernelId}' is not registered with CudaRingKernelRuntime. Active kernels: [{string.Join(", ", _kernels.Keys)}]. Call LaunchAsync(kernelId, gridSize, blockSize) before accessing the kernel.",
+                nameof(kernelId));
         }
 
         if (state.OutputQueue is not DotCompute.Abstractions.RingKernels.IMessageQueue<T> queue)
         {
-            throw new InvalidOperationException($"Output queue not available for kernel '{kernelId}'");
+            throw new InvalidOperationException(
+                $"Output queue for ring kernel '{kernelId}' is not an IMessageQueue<{typeof(T).Name}> — actual type: {state.OutputQueue?.GetType().Name ?? "null"}. " +
+                $"This kernel was launched with a different output message type. ReceiveMessageAsync<T> must match the type declared by the kernel's [RingKernel] output signature.");
         }
 
         try
@@ -1395,7 +1442,9 @@ public sealed partial class CudaRingKernelRuntime : IRingKernelRuntime
 
         if (!_kernels.TryGetValue(kernelId, out var state))
         {
-            throw new ArgumentException($"Kernel '{kernelId}' not found", nameof(kernelId));
+            throw new ArgumentException(
+                $"Ring kernel '{kernelId}' is not registered with CudaRingKernelRuntime. Active kernels: [{string.Join(", ", _kernels.Keys)}]. Call LaunchAsync(kernelId, gridSize, blockSize) before accessing the kernel.",
+                nameof(kernelId));
         }
 
         // Read control block using appropriate method based on allocation type:
@@ -1450,7 +1499,9 @@ public sealed partial class CudaRingKernelRuntime : IRingKernelRuntime
 
         if (!_kernels.TryGetValue(kernelId, out var state))
         {
-            throw new ArgumentException($"Kernel '{kernelId}' not found", nameof(kernelId));
+            throw new ArgumentException(
+                $"Ring kernel '{kernelId}' is not registered with CudaRingKernelRuntime. Active kernels: [{string.Join(", ", _kernels.Keys)}]. Call LaunchAsync(kernelId, gridSize, blockSize) before accessing the kernel.",
+                nameof(kernelId));
         }
 
         // Read control block using appropriate method based on allocation type
@@ -1557,7 +1608,9 @@ public sealed partial class CudaRingKernelRuntime : IRingKernelRuntime
         // Validate capacity before creating logger
         if (capacity <= 0 || (capacity & (capacity - 1)) != 0)
         {
-            throw new ArgumentException("Capacity must be a positive power of 2", nameof(capacity));
+            throw new ArgumentException(
+                $"CudaMessageQueue<{typeof(T).Name}> capacity must be a positive power of 2 (received {capacity}). The ring-buffer algorithm uses bitwise index masking (idx & (capacity-1)), which only wraps correctly for powers of 2. Try 64, 128, 256, 512, 1024 …",
+                nameof(capacity));
         }
 
         // Create a null logger for the message queue
@@ -1592,7 +1645,8 @@ public sealed partial class CudaRingKernelRuntime : IRingKernelRuntime
         {
             // Queue with same name already exists
             queue.Dispose();
-            throw new InvalidOperationException($"Message queue '{queueName}' already exists");
+            throw new InvalidOperationException(
+                $"Named message queue '{queueName}' is already registered in the MessageQueueRegistry (type={typeof(T).Name}, backend=CUDA). Use GetNamedMessageQueueAsync<{typeof(T).Name}>(\"{queueName}\") to retrieve it, or pick a different name for a new queue.");
         }
 
         _logger.LogDebug("Created CUDA message queue '{QueueName}' with capacity {Capacity}", queueName, options.Capacity);
@@ -1716,14 +1770,15 @@ public sealed partial class CudaRingKernelRuntime : IRingKernelRuntime
 
         if (!_kernels.TryGetValue(kernelId, out var state))
         {
-            throw new ArgumentException($"Kernel '{kernelId}' not found", nameof(kernelId));
+            throw new ArgumentException(
+                $"Ring kernel '{kernelId}' is not registered with CudaRingKernelRuntime. Active kernels: [{string.Join(", ", _kernels.Keys)}]. Call LaunchAsync(kernelId, gridSize, blockSize) before accessing the kernel.",
+                nameof(kernelId));
         }
 
         if (state.TelemetryBuffer == null)
         {
             throw new InvalidOperationException(
-                $"Telemetry is not enabled for kernel '{kernelId}'. " +
-                "Call SetTelemetryEnabledAsync(kernelId, true) first.");
+                $"Telemetry is not enabled for ring kernel '{kernelId}' — no TelemetryBuffer was allocated. Call SetTelemetryEnabledAsync(\"{kernelId}\", true) first to provision the pinned-host buffer, then GetTelemetryAsync will return counters.");
         }
 
         _logger.LogTrace("Polling telemetry for kernel '{KernelId}'", kernelId);
@@ -1744,7 +1799,9 @@ public sealed partial class CudaRingKernelRuntime : IRingKernelRuntime
 
         if (!_kernels.TryGetValue(kernelId, out var state))
         {
-            throw new ArgumentException($"Kernel '{kernelId}' not found", nameof(kernelId));
+            throw new ArgumentException(
+                $"Ring kernel '{kernelId}' is not registered with CudaRingKernelRuntime. Active kernels: [{string.Join(", ", _kernels.Keys)}]. Call LaunchAsync(kernelId, gridSize, blockSize) before accessing the kernel.",
+                nameof(kernelId));
         }
 
         if (enabled)
@@ -1800,14 +1857,15 @@ public sealed partial class CudaRingKernelRuntime : IRingKernelRuntime
 
         if (!_kernels.TryGetValue(kernelId, out var state))
         {
-            throw new ArgumentException($"Kernel '{kernelId}' not found", nameof(kernelId));
+            throw new ArgumentException(
+                $"Ring kernel '{kernelId}' is not registered with CudaRingKernelRuntime. Active kernels: [{string.Join(", ", _kernels.Keys)}]. Call LaunchAsync(kernelId, gridSize, blockSize) before accessing the kernel.",
+                nameof(kernelId));
         }
 
         if (state.TelemetryBuffer == null)
         {
             throw new InvalidOperationException(
-                $"Telemetry is not enabled for kernel '{kernelId}'. " +
-                "Call SetTelemetryEnabledAsync(kernelId, true) first.");
+                $"Telemetry is not enabled for ring kernel '{kernelId}' — no TelemetryBuffer was allocated. Call SetTelemetryEnabledAsync(\"{kernelId}\", true) first to provision the pinned-host buffer, then GetTelemetryAsync will return counters.");
         }
 
         _logger.LogDebug("Resetting telemetry for kernel '{KernelId}'", kernelId);
@@ -1833,7 +1891,9 @@ public sealed partial class CudaRingKernelRuntime : IRingKernelRuntime
 
         if (!_kernels.TryGetValue(kernelId, out var state))
         {
-            throw new ArgumentException($"Kernel '{kernelId}' not found", nameof(kernelId));
+            throw new ArgumentException(
+                $"Ring kernel '{kernelId}' is not registered with CudaRingKernelRuntime. Active kernels: [{string.Join(", ", _kernels.Keys)}]. Call LaunchAsync(kernelId, gridSize, blockSize) before accessing the kernel.",
+                nameof(kernelId));
         }
 
         if (state.ControlBlock == IntPtr.Zero)

--- a/src/Backends/DotCompute.Backends.CUDA/RingKernels/GpuRingBuffer.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/RingKernels/GpuRingBuffer.cs
@@ -134,12 +134,16 @@ public sealed class GpuRingBuffer<T> : IGpuRingBuffer
     {
         if (capacity <= 0 || (capacity & (capacity - 1)) != 0)
         {
-            throw new ArgumentException($"Capacity must be a power of 2, got {capacity}", nameof(capacity));
+            throw new ArgumentException(
+                $"GpuRingBuffer<{typeof(T).Name}> capacity must be a positive power of 2 (received {capacity}). The ring-buffer uses bitwise index masking (idx & (capacity-1)) which only wraps correctly for powers of 2. Try 64, 128, 256, 512, 1024 …",
+                nameof(capacity));
         }
 
         if (messageSize <= 0)
         {
-            throw new ArgumentException($"Message size must be positive, got {messageSize}", nameof(messageSize));
+            throw new ArgumentException(
+                $"GpuRingBuffer<{typeof(T).Name}> messageSize must be greater than zero (received {messageSize} bytes). Pass the maximum serialized size of a single message — typically sizeof(T) for POD types or the MemoryPack-serialized size for IRingKernelMessage types.",
+                nameof(messageSize));
         }
 
         _logger = logger;
@@ -163,7 +167,8 @@ public sealed class GpuRingBuffer<T> : IGpuRingBuffer
 
         if (index < 0 || index >= _capacity)
         {
-            throw new ArgumentOutOfRangeException(nameof(index), $"Index {index} out of range [0, {_capacity})");
+            throw new ArgumentOutOfRangeException(nameof(index), index,
+                $"GpuRingBuffer<{typeof(T).Name}> index {index} is outside the valid range [0, {_capacity}) for this buffer (capacity={_capacity}). Use head/tail counters (modulo capacity) to compute the slot index.");
         }
 
         // Serialize message with MemoryPack
@@ -171,7 +176,7 @@ public sealed class GpuRingBuffer<T> : IGpuRingBuffer
         if (bytes.Length > _messageSize)
         {
             throw new InvalidOperationException(
-                $"Serialized message size {bytes.Length} exceeds configured size {_messageSize}");
+                $"Serialized {typeof(T).Name} is {bytes.Length} bytes, which exceeds the configured GpuRingBuffer message size {_messageSize}. Either shrink the message (remove variable-length fields) or allocate the GpuRingBuffer with a larger messageSize — all slots in the ring are fixed-size.");
         }
 
         // Calculate destination offset
@@ -195,7 +200,8 @@ public sealed class GpuRingBuffer<T> : IGpuRingBuffer
             var setDeviceResult = CudaRuntime.cudaSetDevice(_deviceId);
             if (setDeviceResult != CudaError.Success)
             {
-                throw new InvalidOperationException($"cudaSetDevice({_deviceId}) failed: {setDeviceResult}");
+                throw new InvalidOperationException(
+                    $"cudaSetDevice({_deviceId}) failed for GpuRingBuffer<{typeof(T).Name}>: {setDeviceResult} ({(int)setDeviceResult}). Verify device index is valid, the GPU is not in exclusive-process mode, and this thread has a valid CUDA context attached.");
             }
 
             // Device memory - use cudaMemcpy
@@ -207,7 +213,8 @@ public sealed class GpuRingBuffer<T> : IGpuRingBuffer
 
                 if (result != CudaError.Success)
                 {
-                    throw new InvalidOperationException($"cudaMemcpy (H2D) failed: {result}");
+                    throw new InvalidOperationException(
+                        $"Host→Device cudaMemcpy failed while writing {typeof(T).Name} to GpuRingBuffer slot: {result} ({(int)result}). Bytes: {bytes.Length}, destination: 0x{destPtr.ToInt64():X}. Check the buffer is still allocated (not disposed) and the device is not in a fatal error state.");
                 }
             }
             finally
@@ -229,7 +236,8 @@ public sealed class GpuRingBuffer<T> : IGpuRingBuffer
 
         if (index < 0 || index >= _capacity)
         {
-            throw new ArgumentOutOfRangeException(nameof(index), $"Index {index} out of range [0, {_capacity})");
+            throw new ArgumentOutOfRangeException(nameof(index), index,
+                $"GpuRingBuffer<{typeof(T).Name}> index {index} is outside the valid range [0, {_capacity}) for this buffer (capacity={_capacity}). Use head/tail counters (modulo capacity) to compute the slot index.");
         }
 
         // Calculate source offset
@@ -250,7 +258,8 @@ public sealed class GpuRingBuffer<T> : IGpuRingBuffer
             var setDeviceResult = CudaRuntime.cudaSetDevice(_deviceId);
             if (setDeviceResult != CudaError.Success)
             {
-                throw new InvalidOperationException($"cudaSetDevice({_deviceId}) failed: {setDeviceResult}");
+                throw new InvalidOperationException(
+                    $"cudaSetDevice({_deviceId}) failed for GpuRingBuffer<{typeof(T).Name}>: {setDeviceResult} ({(int)setDeviceResult}). Verify device index is valid, the GPU is not in exclusive-process mode, and this thread has a valid CUDA context attached.");
             }
 
             // Device memory - use cudaMemcpy
@@ -262,7 +271,8 @@ public sealed class GpuRingBuffer<T> : IGpuRingBuffer
 
                 if (result != CudaError.Success)
                 {
-                    throw new InvalidOperationException($"cudaMemcpy (D2H) failed: {result}");
+                    throw new InvalidOperationException(
+                        $"Device→Host cudaMemcpy failed while reading {typeof(T).Name} from GpuRingBuffer slot: {result} ({(int)result}). Bytes: {_messageSize}, source: 0x{srcPtr.ToInt64():X}. Check the buffer is still allocated (not disposed) and the device is not in a fatal error state.");
                 }
             }
             finally
@@ -273,7 +283,8 @@ public sealed class GpuRingBuffer<T> : IGpuRingBuffer
 
         // Deserialize with MemoryPack
         return MemoryPackSerializer.Deserialize<T>(bytes)
-            ?? throw new InvalidOperationException("Failed to deserialize message");
+            ?? throw new InvalidOperationException(
+                $"MemoryPackSerializer.Deserialize<{typeof(T).Name}>() returned null for a GpuRingBuffer slot. This indicates corrupted serialized data — possibly a producer wrote with a different schema version or the slot was partially written. Verify [MemoryPackable] type definitions match on both ends.");
     }
 
     /// <summary>
@@ -300,7 +311,8 @@ public sealed class GpuRingBuffer<T> : IGpuRingBuffer
             var setDeviceResult = CudaRuntime.cudaSetDevice(_deviceId);
             if (setDeviceResult != CudaError.Success)
             {
-                throw new InvalidOperationException($"cudaSetDevice({_deviceId}) failed: {setDeviceResult}");
+                throw new InvalidOperationException(
+                    $"cudaSetDevice({_deviceId}) failed for GpuRingBuffer<{typeof(T).Name}>: {setDeviceResult} ({(int)setDeviceResult}). Verify device index is valid, the GPU is not in exclusive-process mode, and this thread has a valid CUDA context attached.");
             }
 
             uint value = 0;
@@ -312,7 +324,8 @@ public sealed class GpuRingBuffer<T> : IGpuRingBuffer
 
             if (result != CudaError.Success)
             {
-                throw new InvalidOperationException($"Failed to read head counter: {result}");
+                throw new InvalidOperationException(
+                    $"cudaMemcpy D2H for head counter failed on GpuRingBuffer<{typeof(T).Name}> (device={_deviceId}): {result} ({(int)result}). Likely causes: buffer disposed, device fault, or pinned-host memory unmapped. Inspect device state via nvidia-smi.");
             }
 
             return value;
@@ -343,7 +356,8 @@ public sealed class GpuRingBuffer<T> : IGpuRingBuffer
             var setDeviceResult = CudaRuntime.cudaSetDevice(_deviceId);
             if (setDeviceResult != CudaError.Success)
             {
-                throw new InvalidOperationException($"cudaSetDevice({_deviceId}) failed: {setDeviceResult}");
+                throw new InvalidOperationException(
+                    $"cudaSetDevice({_deviceId}) failed for GpuRingBuffer<{typeof(T).Name}>: {setDeviceResult} ({(int)setDeviceResult}). Verify device index is valid, the GPU is not in exclusive-process mode, and this thread has a valid CUDA context attached.");
             }
 
             uint value = 0;
@@ -355,7 +369,8 @@ public sealed class GpuRingBuffer<T> : IGpuRingBuffer
 
             if (result != CudaError.Success)
             {
-                throw new InvalidOperationException($"Failed to read tail counter: {result}");
+                throw new InvalidOperationException(
+                    $"cudaMemcpy D2H for tail counter failed on GpuRingBuffer<{typeof(T).Name}> (device={_deviceId}): {result} ({(int)result}). Likely causes: buffer disposed, device fault, or pinned-host memory unmapped. Inspect device state via nvidia-smi.");
             }
 
             return value;
@@ -386,7 +401,8 @@ public sealed class GpuRingBuffer<T> : IGpuRingBuffer
             var setDeviceResult = CudaRuntime.cudaSetDevice(_deviceId);
             if (setDeviceResult != CudaError.Success)
             {
-                throw new InvalidOperationException($"cudaSetDevice({_deviceId}) failed: {setDeviceResult}");
+                throw new InvalidOperationException(
+                    $"cudaSetDevice({_deviceId}) failed for GpuRingBuffer<{typeof(T).Name}>: {setDeviceResult} ({(int)setDeviceResult}). Verify device index is valid, the GPU is not in exclusive-process mode, and this thread has a valid CUDA context attached.");
             }
 
             var result = CudaRuntime.cudaMemcpy(
@@ -397,7 +413,8 @@ public sealed class GpuRingBuffer<T> : IGpuRingBuffer
 
             if (result != CudaError.Success)
             {
-                throw new InvalidOperationException($"Failed to write head counter: {result}");
+                throw new InvalidOperationException(
+                    $"cudaMemcpy H2D for head counter failed on GpuRingBuffer<{typeof(T).Name}> (device={_deviceId}, value={value}): {result} ({(int)result}). Likely causes: buffer disposed, device fault, or pinned-host memory unmapped. Inspect device state via nvidia-smi.");
             }
         }
     }
@@ -429,7 +446,8 @@ public sealed class GpuRingBuffer<T> : IGpuRingBuffer
             var setDeviceResult = CudaRuntime.cudaSetDevice(_deviceId);
             if (setDeviceResult != CudaError.Success)
             {
-                throw new InvalidOperationException($"cudaSetDevice({_deviceId}) failed: {setDeviceResult}");
+                throw new InvalidOperationException(
+                    $"cudaSetDevice({_deviceId}) failed for GpuRingBuffer<{typeof(T).Name}>: {setDeviceResult} ({(int)setDeviceResult}). Verify device index is valid, the GPU is not in exclusive-process mode, and this thread has a valid CUDA context attached.");
             }
 
             var result = CudaRuntime.cudaMemcpy(
@@ -440,7 +458,8 @@ public sealed class GpuRingBuffer<T> : IGpuRingBuffer
 
             if (result != CudaError.Success)
             {
-                throw new InvalidOperationException($"Failed to write tail counter: {result}");
+                throw new InvalidOperationException(
+                    $"cudaMemcpy H2D for tail counter failed on GpuRingBuffer<{typeof(T).Name}> (device={_deviceId}, value={value}): {result} ({(int)result}). Likely causes: buffer disposed, device fault, or pinned-host memory unmapped. Inspect device state via nvidia-smi.");
             }
         }
     }
@@ -484,7 +503,8 @@ public sealed class GpuRingBuffer<T> : IGpuRingBuffer
         var setDeviceResult = CudaRuntime.cudaSetDevice(_deviceId);
         if (setDeviceResult != CudaError.Success)
         {
-            throw new InvalidOperationException($"cudaSetDevice({_deviceId}) failed: {setDeviceResult}");
+            throw new InvalidOperationException(
+                $"cudaSetDevice({_deviceId}) failed during GpuRingBuffer<{typeof(T).Name}> allocation: {setDeviceResult} ({(int)setDeviceResult}). Verify device index is valid and the GPU is available.");
         }
 
         // Calculate total buffer size
@@ -500,7 +520,8 @@ public sealed class GpuRingBuffer<T> : IGpuRingBuffer
             if (result != CudaError.Success)
             {
                 throw new InvalidOperationException(
-                    $"cudaMallocManaged failed for buffer (size={bufferSize}): {result}");
+                    $"cudaMallocManaged (unified memory) for GpuRingBuffer<{typeof(T).Name}> failed: {result} ({(int)result}). Requested {bufferSize:N0} bytes on device {_deviceId} (capacity={_capacity}, messageSize={_messageSize}). " +
+                    $"Common causes: GPU out of memory, unified memory unsupported on this hardware/driver (check cudaDeviceGetAttribute for ManagedMemory), or WSL2 limitations. Try useUnifiedMemory=false or reduce capacity.");
             }
 
             _logger?.LogDebug("Allocated unified memory buffer: ptr=0x{Ptr:X}, size={Size}",
@@ -511,7 +532,8 @@ public sealed class GpuRingBuffer<T> : IGpuRingBuffer
             if (result != CudaError.Success)
             {
                 CudaRuntime.cudaFree(_deviceBuffer);
-                throw new InvalidOperationException($"cudaMallocManaged failed for head: {result}");
+                throw new InvalidOperationException(
+                    $"cudaMallocManaged for GpuRingBuffer head counter (4 bytes) failed on device {_deviceId}: {result} ({(int)result}). Data buffer was freed. This is unusual — the main buffer allocated but a 4-byte counter could not, suggesting internal-table exhaustion in the CUDA driver.");
             }
 
             result = CudaRuntime.cudaMallocManaged(ref _deviceTail, sizeof(uint), 0x01);
@@ -519,7 +541,8 @@ public sealed class GpuRingBuffer<T> : IGpuRingBuffer
             {
                 CudaRuntime.cudaFree(_deviceBuffer);
                 CudaRuntime.cudaFree(_deviceHead);
-                throw new InvalidOperationException($"cudaMallocManaged failed for tail: {result}");
+                throw new InvalidOperationException(
+                    $"cudaMallocManaged for GpuRingBuffer tail counter (4 bytes) failed on device {_deviceId}: {result} ({(int)result}). Data buffer and head counter were freed. This is unusual — the main buffer allocated but a 4-byte counter could not, suggesting internal-table exhaustion in the CUDA driver.");
             }
 
             _logger?.LogDebug("Allocated unified memory counters: head=0x{Head:X}, tail=0x{Tail:X}",
@@ -533,7 +556,8 @@ public sealed class GpuRingBuffer<T> : IGpuRingBuffer
             if (result != CudaError.Success)
             {
                 throw new InvalidOperationException(
-                    $"cudaMalloc failed for buffer (size={bufferSize}): {result}");
+                    $"cudaMalloc (device memory) for GpuRingBuffer<{typeof(T).Name}> failed: {result} ({(int)result}). Requested {bufferSize:N0} bytes on device {_deviceId} (capacity={_capacity}, messageSize={_messageSize}). " +
+                    $"Common causes: GPU out of memory (check nvidia-smi free VRAM), fragmentation, or device in error state. Reduce capacity or messageSize, or free other GPU allocations.");
             }
 
             _logger?.LogDebug("Allocated device memory buffer: ptr=0x{Ptr:X}, size={Size}",
@@ -544,7 +568,8 @@ public sealed class GpuRingBuffer<T> : IGpuRingBuffer
             if (result != CudaError.Success)
             {
                 CudaRuntime.cudaFree(_deviceBuffer);
-                throw new InvalidOperationException($"cudaMalloc failed for head: {result}");
+                throw new InvalidOperationException(
+                    $"cudaMalloc for GpuRingBuffer head counter (4 bytes) failed on device {_deviceId}: {result} ({(int)result}). Data buffer was freed. This is unusual — the main buffer allocated but a 4-byte counter could not, suggesting internal-table exhaustion in the CUDA driver.");
             }
 
             result = CudaRuntime.cudaMalloc(ref _deviceTail, sizeof(uint));
@@ -552,7 +577,8 @@ public sealed class GpuRingBuffer<T> : IGpuRingBuffer
             {
                 CudaRuntime.cudaFree(_deviceBuffer);
                 CudaRuntime.cudaFree(_deviceHead);
-                throw new InvalidOperationException($"cudaMalloc failed for tail: {result}");
+                throw new InvalidOperationException(
+                    $"cudaMalloc for GpuRingBuffer tail counter (4 bytes) failed on device {_deviceId}: {result} ({(int)result}). Data buffer and head counter were freed. This is unusual — the main buffer allocated but a 4-byte counter could not, suggesting internal-table exhaustion in the CUDA driver.");
             }
 
             _logger?.LogDebug("Allocated device memory counters: head=0x{Head:X}, tail=0x{Tail:X}",

--- a/src/Backends/DotCompute.Backends.CUDA/RingKernels/RoutingTableBuilder.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/RingKernels/RoutingTableBuilder.cs
@@ -45,7 +45,9 @@ public sealed class RoutingTableBuilder : IDisposable
     /// <exception cref="ArgumentNullException">Thrown if context is null.</exception>
     public RoutingTableBuilder(CudaContext context)
     {
-        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _context = context ?? throw new ArgumentNullException(
+            nameof(context),
+            "RoutingTableBuilder requires a CudaContext — the routing table is allocated in device memory and needs a live context. Obtain it from CudaAccelerator.Context.");
     }
 
     /// <summary>
@@ -63,7 +65,9 @@ public sealed class RoutingTableBuilder : IDisposable
 
         if (string.IsNullOrWhiteSpace(kernelName))
         {
-            throw new ArgumentException("Kernel name cannot be null or empty.", nameof(kernelName));
+            throw new ArgumentException(
+                $"RegisterKernel: kernelName must be a non-empty string (received '{kernelName ?? "<null>"}'). Kernel names are hashed to 16-bit IDs — a distinct name per kernel is required.",
+                nameof(kernelName));
         }
 
         var kernelId = HashKernelName(kernelName);
@@ -71,7 +75,9 @@ public sealed class RoutingTableBuilder : IDisposable
         // Check for duplicate kernel names
         if (_kernels.Any(k => k.KernelId == kernelId))
         {
-            throw new ArgumentException($"Kernel '{kernelName}' (ID: 0x{kernelId:X4}) is already registered.", nameof(kernelName));
+            throw new ArgumentException(
+                $"Kernel '{kernelName}' (hashed id 0x{kernelId:X4}) is already registered in the routing table. Each kernel name must be unique within a routing table — if this is a hash collision, choose a distinct name for the second kernel.",
+                nameof(kernelName));
         }
 
         var queueIndex = _kernels.Count;
@@ -113,12 +119,14 @@ public sealed class RoutingTableBuilder : IDisposable
 
         if (_kernels.Count == 0)
         {
-            throw new InvalidOperationException("No kernels registered. Cannot build empty routing table.");
+            throw new InvalidOperationException(
+                "RoutingTableBuilder has no kernels registered — cannot build an empty routing table. Call RegisterKernel(name, outputQueuePtr, controlBlockPtr) for at least one kernel before Build().");
         }
 
         if (_kernels.Count > 65535)
         {
-            throw new InvalidOperationException($"Too many kernels registered ({_kernels.Count}). Maximum is 65535.");
+            throw new InvalidOperationException(
+                $"RoutingTableBuilder has {_kernels.Count} kernels but the encoded queue index is a uint16 (max 65535). Reduce the number of kernels in a single routing table, or shard kernels across multiple routing tables.");
         }
 
         // Calculate optimal hash table capacity
@@ -149,7 +157,8 @@ public sealed class RoutingTableBuilder : IDisposable
         // Validate before returning
         if (!routingTable.Validate())
         {
-            throw new InvalidOperationException("Built routing table failed validation.");
+            throw new InvalidOperationException(
+                $"Built routing table failed post-validation — the device-side hash table may have a duplicate slot or inconsistent kernel count ({_kernels.Count}). This indicates a bug in RoutingTableBuilder or memory corruption during upload; inspect device memory via cuda-gdb.");
         }
 
         return routingTable;
@@ -186,7 +195,8 @@ public sealed class RoutingTableBuilder : IDisposable
 
             if (probe >= capacity)
             {
-                throw new InvalidOperationException($"Hash table full. Cannot insert kernel '{kernel.KernelName}' (ID: 0x{kernel.KernelId:X4}).");
+                throw new InvalidOperationException(
+                    $"Routing hash table is full while inserting kernel '{kernel.KernelName}' (id 0x{kernel.KernelId:X4}). The linear-probe loop exhausted all slots — reduce the number of kernels in this routing table, or increase the hash-table size constant in the routing layout.");
             }
         }
 
@@ -210,7 +220,8 @@ public sealed class RoutingTableBuilder : IDisposable
 
             if (result != CudaError.Success)
             {
-                throw new InvalidOperationException($"Failed to copy hash table to device: {result}");
+                throw new InvalidOperationException(
+                    $"cudaMemcpy H2D for kernel hash table failed: {result} ({(int)result}). Device memory was allocated but upload failed — likely GPU fault or context loss. Inspect nvidia-smi and check for kernel crashes.");
             }
         }
         finally
@@ -238,7 +249,8 @@ public sealed class RoutingTableBuilder : IDisposable
 
             if (result != CudaError.Success)
             {
-                throw new InvalidOperationException($"Failed to copy output queues to device: {result}");
+                throw new InvalidOperationException(
+                    $"cudaMemcpy H2D for {_kernels.Count} output-queue pointer(s) failed: {result} ({(int)result}). Device memory was allocated but upload failed — likely GPU fault or context loss. Inspect nvidia-smi and check for kernel crashes.");
             }
         }
         finally
@@ -270,7 +282,8 @@ public sealed class RoutingTableBuilder : IDisposable
 
             if (result != CudaError.Success)
             {
-                throw new InvalidOperationException($"Failed to copy control blocks to device: {result}");
+                throw new InvalidOperationException(
+                    $"cudaMemcpy H2D for {_kernels.Count} control-block pointer(s) failed: {result} ({(int)result}). Device memory was allocated but upload failed — likely GPU fault or context loss. Inspect nvidia-smi and check for kernel crashes.");
             }
         }
         finally

--- a/src/Backends/DotCompute.Backends.CUDA/RingKernels/TopicRegistryBuilder.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/RingKernels/TopicRegistryBuilder.cs
@@ -44,7 +44,9 @@ public sealed class TopicRegistryBuilder : IDisposable
     /// <exception cref="ArgumentNullException">Thrown if context is null.</exception>
     public TopicRegistryBuilder(CudaContext context)
     {
-        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _context = context ?? throw new ArgumentNullException(
+            nameof(context),
+            "TopicRegistryBuilder requires a CudaContext — the topic registry is allocated in device memory and needs a live context. Obtain it from CudaAccelerator.Context.");
     }
 
     /// <summary>
@@ -63,7 +65,9 @@ public sealed class TopicRegistryBuilder : IDisposable
 
         if (string.IsNullOrWhiteSpace(topicName))
         {
-            throw new ArgumentException("Topic name cannot be null or empty.", nameof(topicName));
+            throw new ArgumentException(
+                $"Subscribe: topic name must be a non-empty string (received '{topicName ?? "<null>"}'). Topic names are hashed to 32-bit IDs — a distinct name per topic is required.",
+                nameof(topicName));
         }
 
         var topicId = HashTopicName(topicName);
@@ -71,7 +75,9 @@ public sealed class TopicRegistryBuilder : IDisposable
         // Check for duplicate subscriptions (same topic + kernel)
         if (_subscriptions.Any(s => s.TopicId == topicId && s.KernelId == kernelId))
         {
-            throw new ArgumentException($"Kernel 0x{kernelId:X4} is already subscribed to topic '{topicName}' (ID: 0x{topicId:X8}).", nameof(kernelId));
+            throw new ArgumentException(
+                $"Kernel 0x{kernelId:X4} is already subscribed to topic '{topicName}' (topicId=0x{topicId:X8}). Each (topicId, kernelId) pair can appear at most once in the registry — remove the existing subscription first or subscribe a different kernel.",
+                nameof(kernelId));
         }
 
         var subscriptionIndex = _subscriptions.Count;
@@ -101,7 +107,9 @@ public sealed class TopicRegistryBuilder : IDisposable
     {
         if (kernelIds.Length != queueIndices.Length)
         {
-            throw new ArgumentException("kernelIds and queueIndices must have the same length.");
+            throw new ArgumentException(
+                $"SubscribeMultiple: kernelIds.Length ({kernelIds.Length}) must equal queueIndices.Length ({queueIndices.Length}). Each subscribing kernel needs a matching queue index — the arrays index the same subscription records.",
+                nameof(queueIndices));
         }
 
         var count = 0;
@@ -144,12 +152,14 @@ public sealed class TopicRegistryBuilder : IDisposable
 
         if (_subscriptions.Count == 0)
         {
-            throw new InvalidOperationException("No subscriptions registered. Cannot build empty topic registry.");
+            throw new InvalidOperationException(
+                "TopicRegistryBuilder has no subscriptions — cannot build an empty topic registry. Call Subscribe(topicName, kernelId, queueIndex) for at least one topic/kernel pair before Build().");
         }
 
         if (_subscriptions.Count > 65535)
         {
-            throw new InvalidOperationException($"Too many subscriptions ({_subscriptions.Count}). Maximum is 65535.");
+            throw new InvalidOperationException(
+                $"TopicRegistryBuilder has {_subscriptions.Count} subscriptions but the encoded subscription index is a uint16 (max 65535). Reduce the number of (topic, kernel) subscriptions, or shard topics across multiple registries.");
         }
 
         // Sort subscriptions by topic ID for efficient scanning
@@ -182,7 +192,8 @@ public sealed class TopicRegistryBuilder : IDisposable
         // Validate before returning
         if (!registry.Validate())
         {
-            throw new InvalidOperationException("Built topic registry failed validation.");
+            throw new InvalidOperationException(
+                $"Built topic registry failed post-validation — the device-side hash table may have a duplicate slot or inconsistent Subscription count ({_subscriptions.Count}). This indicates a bug in TopicRegistryBuilder or memory corruption during upload; inspect device memory via cuda-gdb.");
         }
 
         return registry;
@@ -226,7 +237,8 @@ public sealed class TopicRegistryBuilder : IDisposable
 
             if (result != CudaError.Success)
             {
-                throw new InvalidOperationException($"Failed to copy subscriptions to device: {result}");
+                throw new InvalidOperationException(
+                    $"cudaMemcpy H2D for {subscriptions.Length} subscription record(s) failed: {result} ({(int)result}). Device memory was allocated but upload failed — likely GPU fault or context loss. Inspect nvidia-smi and check for kernel crashes.");
             }
         }
         finally
@@ -289,7 +301,8 @@ public sealed class TopicRegistryBuilder : IDisposable
 
             if (probe >= capacity)
             {
-                throw new InvalidOperationException($"Hash table full. Cannot insert topic 0x{topicId:X8}.");
+                throw new InvalidOperationException(
+                    $"Topic hash table is full while inserting topic 0x{topicId:X8} (capacity={capacity}). The linear-probe loop exhausted all slots — reduce the number of unique topics, or increase the hash-table size constant in the registry layout.");
             }
         }
 
@@ -305,7 +318,8 @@ public sealed class TopicRegistryBuilder : IDisposable
 
             if (result != CudaError.Success)
             {
-                throw new InvalidOperationException($"Failed to copy hash table to device: {result}");
+                throw new InvalidOperationException(
+                    $"cudaMemcpy H2D for topic hash table failed: {result} ({(int)result}). Device memory was allocated but upload failed — likely GPU fault or context loss. Inspect nvidia-smi and check for kernel crashes.");
             }
         }
         finally

--- a/src/Core/DotCompute.Core/Debugging/Analytics/KernelDebugAnalyzer.cs
+++ b/src/Core/DotCompute.Core/Debugging/Analytics/KernelDebugAnalyzer.cs
@@ -314,7 +314,9 @@ public sealed partial class KernelDebugAnalyzer : IDisposable
         if (runCount < 2)
         {
 
-            throw new ArgumentException("Run count must be at least 2", nameof(runCount));
+            throw new ArgumentException(
+                $"Determinism validation for kernel '{kernelName}' requires at least 2 runs to compare outputs (received {runCount}). A single run cannot detect non-determinism. Pass 3-10 runs for a meaningful test.",
+                nameof(runCount));
         }
 
         LogDeterminismValidationStarting(_logger, kernelName, runCount);

--- a/src/Core/DotCompute.Core/Debugging/Analytics/KernelProfiler.cs
+++ b/src/Core/DotCompute.Core/Debugging/Analytics/KernelProfiler.cs
@@ -72,7 +72,8 @@ public sealed partial class KernelProfiler : IDisposable
         else
         {
             LogSessionAlreadyExists(sessionId);
-            throw new InvalidOperationException($"Profiling session '{sessionId}' already exists.");
+            throw new InvalidOperationException(
+                $"Profiling session '{sessionId}' is already active for this KernelProfiler. Stop the existing session via StopProfiling(sessionId) before starting a new one with the same id, or use a unique session identifier per profiling run.");
         }
 
         return session;
@@ -93,7 +94,8 @@ public sealed partial class KernelProfiler : IDisposable
         if (!_activeSessions.TryRemove(sessionId, out var session))
         {
             LogSessionNotFound(sessionId);
-            throw new InvalidOperationException($"Profiling session '{sessionId}' not found.");
+            throw new InvalidOperationException(
+                $"Profiling session '{sessionId}' is not active. StopProfiling can only be called with an id returned by a prior StartProfiling call — check for session-id mismatches, double-stop, or sessions that have already been removed via timeout/disposal.");
         }
 
         var endTime = DateTime.UtcNow;

--- a/src/Core/DotCompute.Core/Debugging/Core/EnhancedKernelValidator.cs
+++ b/src/Core/DotCompute.Core/Debugging/Core/EnhancedKernelValidator.cs
@@ -18,7 +18,9 @@ namespace DotCompute.Core.Debugging.Core;
 public sealed partial class EnhancedKernelValidator(ILogger<EnhancedKernelValidator> logger, DebugServiceOptions? options = null) : IDisposable
 {
 #pragma warning disable CA1823 // Avoid unused private fields
-    private readonly ILogger<EnhancedKernelValidator> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    private readonly ILogger<EnhancedKernelValidator> _logger = logger ?? throw new ArgumentNullException(
+        nameof(logger),
+        "ILogger<EnhancedKernelValidator> is required. Register logging via AddLogging() in startup so validation diagnostics are captured.");
 #pragma warning restore CA1823 // Avoid unused private fields
     private readonly DebugServiceOptions? _options = options;
     private readonly ConcurrentDictionary<string, ValidationProfile> _validationProfiles = new();

--- a/src/Core/DotCompute.Core/Debugging/Core/KernelDebugger.cs
+++ b/src/Core/DotCompute.Core/Debugging/Core/KernelDebugger.cs
@@ -19,7 +19,9 @@ namespace DotCompute.Core.Debugging.Core;
 /// </summary>
 public sealed partial class KernelDebugger(ILogger<KernelDebugger> logger, DebugServiceOptions? options = null) : IDisposable
 {
-    private readonly ILogger<KernelDebugger> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    private readonly ILogger<KernelDebugger> _logger = logger ?? throw new ArgumentNullException(
+        nameof(logger),
+        "ILogger<KernelDebugger> is required. Pass a logger from ILoggerFactory so debug events are emitted to your configured log pipeline.");
     private readonly DebugServiceOptions? _options = options;
     private readonly ConcurrentDictionary<string, IAccelerator> _accelerators = new();
     private readonly ConcurrentQueue<KernelExecutionResult> _executionHistory = new();

--- a/src/Core/DotCompute.Core/Debugging/Core/KernelValidator.cs
+++ b/src/Core/DotCompute.Core/Debugging/Core/KernelValidator.cs
@@ -23,8 +23,12 @@ public sealed partial class KernelValidator(
     ILogger<KernelValidator> logger,
     DebugServiceOptions options) : IDisposable
 {
-    private readonly ILogger<KernelValidator> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-    private readonly DebugServiceOptions _options = options ?? throw new ArgumentNullException(nameof(options));
+    private readonly ILogger<KernelValidator> _logger = logger ?? throw new ArgumentNullException(
+        nameof(logger),
+        "ILogger<KernelValidator> is required. Register logging via AddLogging() so cross-backend validation events are captured.");
+    private readonly DebugServiceOptions _options = options ?? throw new ArgumentNullException(
+        nameof(options),
+        "DebugServiceOptions is required for KernelValidator — this configures tolerance thresholds, fail-on-error behavior, etc. Pass DebugServiceOptions.Default for sensible defaults.");
     private readonly ConcurrentDictionary<string, IAccelerator> _accelerators = new();
     private bool _disposed;
 
@@ -271,7 +275,9 @@ public sealed partial class KernelValidator(
         var resultsList = results.ToList();
         if (resultsList.Count < 2)
         {
-            throw new ArgumentException("At least two results are required for comparison", nameof(results));
+            throw new ArgumentException(
+                $"Cross-backend comparison requires at least two KernelExecutionResult instances to compare against each other (received {resultsList.Count}). Collect results from multiple backends (e.g., CPU and CUDA) before invoking Compare.",
+                nameof(results));
         }
 
         var kernelName = resultsList[0].KernelName ?? "Unknown";

--- a/src/Core/DotCompute.Core/Debugging/DebugIntegratedOrchestrator.cs
+++ b/src/Core/DotCompute.Core/Debugging/DebugIntegratedOrchestrator.cs
@@ -170,7 +170,8 @@ public partial class DebugIntegratedOrchestrator(
                     if (_options.FailOnValidationErrors)
                     {
                         throw new InvalidOperationException(
-                            $"Kernel {kernelName} failed pre-execution validation: {preValidation.Issues.First()}");
+                            $"Kernel '{kernelName}' failed pre-execution validation with {preValidation.Issues.Count} critical issue(s): {string.Join("; ", preValidation.Issues)}. " +
+                            $"Fix the reported problems or set DebugServiceOptions.FailOnValidationErrors=false to continue despite validation errors (not recommended in production).");
                     }
                 }
             }

--- a/src/Core/DotCompute.Core/Debugging/DebugServiceExtensions.cs
+++ b/src/Core/DotCompute.Core/Debugging/DebugServiceExtensions.cs
@@ -199,7 +199,8 @@ public static class ServiceDecoratorExtensions
         where TService : class
     {
         // Find the existing service registration
-        var existingDescriptor = services.LastOrDefault(x => x.ServiceType == typeof(TService)) ?? throw new InvalidOperationException($"Service of type {typeof(TService).Name} is not registered.");
+        var existingDescriptor = services.LastOrDefault(x => x.ServiceType == typeof(TService)) ?? throw new InvalidOperationException(
+            $"Cannot decorate {typeof(TService).FullName}: no existing registration found in the IServiceCollection. Register the service first (e.g., services.Add{typeof(TService).Name}()) before calling Decorate<{typeof(TService).Name}>(...).");
 
         // Create a new descriptor that wraps the original
         var decoratedDescriptor = ServiceDescriptor.Describe(
@@ -224,7 +225,8 @@ public static class ServiceDecoratorExtensions
                 }
                 else
                 {
-                    throw new InvalidOperationException("Invalid service descriptor");
+                    throw new InvalidOperationException(
+                        $"Cannot decorate {typeof(TService).FullName}: the existing ServiceDescriptor has no ImplementationInstance, ImplementationFactory, or ImplementationType. This descriptor is malformed — re-register the service with one of the three forms before decorating.");
                 }
 
                 // Apply the decorator

--- a/src/Core/DotCompute.Core/Debugging/KernelDebugReporter.cs
+++ b/src/Core/DotCompute.Core/Debugging/KernelDebugReporter.cs
@@ -303,7 +303,9 @@ internal sealed partial class KernelDebugReporter(ILogger<KernelDebugReporter> l
                 ReportFormat.Xml => await ExportToXmlAsync(report),
                 ReportFormat.Csv => await ExportToCsvAsync(report),
                 ReportFormat.PlainText => await ExportToTextAsync(report),
-                _ => throw new ArgumentException($"Unsupported report format: {format}")
+                _ => throw new ArgumentException(
+                    $"Unsupported ReportFormat value '{format}' ({(int)format}) for KernelDebugReporter.ExportAsync. Supported formats: Json, Xml, Csv, PlainText. Add a new ExportTo*Async method if a new format is needed.",
+                    nameof(format))
             };
         }
         catch (Exception ex)

--- a/src/Core/DotCompute.Core/Debugging/Services/DebugReportGenerator.cs
+++ b/src/Core/DotCompute.Core/Debugging/Services/DebugReportGenerator.cs
@@ -82,7 +82,9 @@ public sealed partial class DebugReportGenerator(ILogger<DebugReportGenerator> l
             ReportFormat.Html => GenerateHtmlCrossValidationReport(validationResult),
             ReportFormat.Json => GenerateJsonCrossValidationReport(validationResult),
             ReportFormat.PlainText => GeneratePlainTextCrossValidationReport(validationResult),
-            _ => throw new ArgumentException($"Unsupported report format: {format}")
+            _ => throw new ArgumentException(
+                $"Unsupported ReportFormat value '{format}' ({(int)format}). Supported formats: Markdown, Html, Json, PlainText. Add a new Generate*Report method and a switch case here if you need a different format.",
+                nameof(format))
         };
     }
 
@@ -105,7 +107,9 @@ public sealed partial class DebugReportGenerator(ILogger<DebugReportGenerator> l
             ReportFormat.Html => GenerateHtmlPerformanceReport(performanceData),
             ReportFormat.Json => GenerateJsonPerformanceReport(performanceData),
             ReportFormat.PlainText => GeneratePlainTextPerformanceReport(performanceData),
-            _ => throw new ArgumentException($"Unsupported report format: {format}")
+            _ => throw new ArgumentException(
+                $"Unsupported ReportFormat value '{format}' ({(int)format}). Supported formats: Markdown, Html, Json, PlainText. Add a new Generate*Report method and a switch case here if you need a different format.",
+                nameof(format))
         };
     }
 
@@ -128,7 +132,9 @@ public sealed partial class DebugReportGenerator(ILogger<DebugReportGenerator> l
             ReportFormat.Html => GenerateHtmlDeterminismReport(determinismResult),
             ReportFormat.Json => GenerateJsonDeterminismReport(determinismResult),
             ReportFormat.PlainText => GeneratePlainTextDeterminismReport(determinismResult),
-            _ => throw new ArgumentException($"Unsupported report format: {format}")
+            _ => throw new ArgumentException(
+                $"Unsupported ReportFormat value '{format}' ({(int)format}). Supported formats: Markdown, Html, Json, PlainText. Add a new Generate*Report method and a switch case here if you need a different format.",
+                nameof(format))
         };
     }
 
@@ -151,7 +157,9 @@ public sealed partial class DebugReportGenerator(ILogger<DebugReportGenerator> l
             ReportFormat.Html => GenerateHtmlMemoryReport(memoryAnalysis),
             ReportFormat.Json => GenerateJsonMemoryReport(memoryAnalysis),
             ReportFormat.PlainText => GeneratePlainTextMemoryReport(memoryAnalysis),
-            _ => throw new ArgumentException($"Unsupported report format: {format}")
+            _ => throw new ArgumentException(
+                $"Unsupported ReportFormat value '{format}' ({(int)format}). Supported formats: Markdown, Html, Json, PlainText. Add a new Generate*Report method and a switch case here if you need a different format.",
+                nameof(format))
         };
     }
 
@@ -198,7 +206,9 @@ public sealed partial class DebugReportGenerator(ILogger<DebugReportGenerator> l
             ReportFormat.Html => GenerateHtmlReport(debugData),
             ReportFormat.Json => GenerateJsonReport(debugData),
             ReportFormat.PlainText => GeneratePlainTextReport(debugData),
-            _ => throw new ArgumentException($"Unsupported report format: {format}")
+            _ => throw new ArgumentException(
+                $"Unsupported ReportFormat value '{format}' ({(int)format}). Supported formats: Markdown, Html, Json, PlainText. Add a new Generate*Report method and a switch case here if you need a different format.",
+                nameof(format))
         };
     }
 

--- a/src/Core/DotCompute.Core/Debugging/Services/KernelDebugOrchestrator.cs
+++ b/src/Core/DotCompute.Core/Debugging/Services/KernelDebugOrchestrator.cs
@@ -545,7 +545,9 @@ public sealed partial class KernelDebugOrchestrator : IKernelDebugService, IDisp
         if (iterations < 2)
         {
 
-            throw new ArgumentException("Iteration count must be at least 2", nameof(iterations));
+            throw new ArgumentException(
+                $"Determinism validation for kernel '{kernelName}' requires at least 2 iterations to detect non-determinism (received {iterations}). A single iteration cannot produce a comparison; pass 3-10 for a meaningful test.",
+                nameof(iterations));
         }
 
 

--- a/src/Core/DotCompute.Core/Execution/AdaptiveOptimizer.cs
+++ b/src/Core/DotCompute.Core/Execution/AdaptiveOptimizer.cs
@@ -25,7 +25,9 @@ public class AdaptiveOptimizer
     /// <param name="logger">The logger.</param>
     public AdaptiveOptimizer(ILogger logger)
     {
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _logger = logger ?? throw new ArgumentNullException(
+            nameof(logger),
+            "ILogger is required for AdaptiveOptimizer. Pass a non-null logger from ILoggerFactory to capture ML-driven strategy-selection decisions.");
     }
     /// <summary>
     /// Gets recommend strategy.

--- a/src/Core/DotCompute.Core/Execution/Analysis/DependencyAnalyzer.cs
+++ b/src/Core/DotCompute.Core/Execution/Analysis/DependencyAnalyzer.cs
@@ -36,7 +36,9 @@ namespace DotCompute.Core.Execution.Analysis
 
         #endregion
 
-        private readonly ILogger _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        private readonly ILogger _logger = logger ?? throw new ArgumentNullException(
+            nameof(logger),
+            "ILogger is required for DependencyAnalyzer. Pass a non-null logger from ILoggerFactory to capture graph-analysis diagnostics.");
 
         /// <summary>
         /// Analyzes data dependencies for parallel execution between input and output buffers.

--- a/src/Core/DotCompute.Core/Execution/Analysis/DependencyGraph.cs
+++ b/src/Core/DotCompute.Core/Execution/Analysis/DependencyGraph.cs
@@ -186,7 +186,8 @@ namespace DotCompute.Core.Execution.Analysis
         {
             if (visiting.Contains(node))
             {
-                throw new InvalidOperationException($"Circular dependency detected involving node {node}");
+                throw new InvalidOperationException(
+                    $"Circular dependency detected in DependencyGraph involving node {node}. Cycle detected while performing topological sort — the graph must be a DAG. Break the cycle by removing one of the back-edges or restructuring the layer dependencies.");
             }
 
             if (visited.Contains(node))

--- a/src/Core/DotCompute.Core/Execution/Analysis/DevicePerformanceEstimator.cs
+++ b/src/Core/DotCompute.Core/Execution/Analysis/DevicePerformanceEstimator.cs
@@ -37,7 +37,9 @@ namespace DotCompute.Core.Execution.Analysis
 
         #endregion
 
-        private readonly ILogger _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        private readonly ILogger _logger = logger ?? throw new ArgumentNullException(
+            nameof(logger),
+            "ILogger is required for DevicePerformanceEstimator. Pass a non-null logger (or construct via the parameterless constructor which uses NullLogger for testing).");
         private readonly Dictionary<string, DevicePerformanceCache> _performanceCache = [];
 
         /// <summary>
@@ -106,7 +108,8 @@ namespace DotCompute.Core.Execution.Analysis
 
             if (workloadSize <= 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(workloadSize), "Workload size must be greater than zero.");
+                throw new ArgumentOutOfRangeException(nameof(workloadSize), workloadSize,
+                    $"Workload size must be greater than zero for performance estimation (received {workloadSize}). Pass the total number of elements or operations the workload will process on device '{device.Info.Id}'.");
             }
 
 
@@ -144,7 +147,9 @@ namespace DotCompute.Core.Execution.Analysis
         {
             if (string.IsNullOrEmpty(deviceId))
             {
-                throw new ArgumentException("Device ID cannot be null or empty.", nameof(deviceId));
+                throw new ArgumentException(
+                    $"Device ID must be a non-empty string for RecordPerformanceData (received '{deviceId ?? "<null>"}'). Pass IAccelerator.Info.Id to correlate runtime execution data with the estimator cache.",
+                    nameof(deviceId));
             }
 
 

--- a/src/Core/DotCompute.Core/Execution/Analysis/KernelPerformanceStatistics.cs
+++ b/src/Core/DotCompute.Core/Execution/Analysis/KernelPerformanceStatistics.cs
@@ -148,14 +148,16 @@ namespace DotCompute.Core.Execution.Analysis
             if (additionalExecutions < 0)
             {
 
-                throw new ArgumentOutOfRangeException(nameof(additionalExecutions), "Additional executions cannot be negative.");
+                throw new ArgumentOutOfRangeException(nameof(additionalExecutions), additionalExecutions,
+                    $"WithAdditionalExecution requires a non-negative execution count (received {additionalExecutions}). Pass 0 if no new executions occurred, or the exact positive count to add.");
             }
 
 
             if (additionalTimeMs < 0)
             {
 
-                throw new ArgumentOutOfRangeException(nameof(additionalTimeMs), "Additional time cannot be negative.");
+                throw new ArgumentOutOfRangeException(nameof(additionalTimeMs), additionalTimeMs,
+                    $"WithAdditionalExecution requires a non-negative duration in milliseconds (received {additionalTimeMs}). Use 0 for near-instant kernels; negative durations indicate a timing bug upstream.");
             }
 
 

--- a/src/Core/DotCompute.Core/Execution/DeviceWorkQueue.cs
+++ b/src/Core/DotCompute.Core/Execution/DeviceWorkQueue.cs
@@ -38,9 +38,13 @@ namespace DotCompute.Core.Execution
         /// </exception>
         public DeviceWorkScheduler(IAccelerator device, int deviceIndex, ILogger logger)
         {
-            _device = device ?? throw new ArgumentNullException(nameof(device));
+            _device = device ?? throw new ArgumentNullException(
+                nameof(device),
+                "DeviceWorkScheduler requires the IAccelerator whose work queue it manages. Pass the device the scheduler will dispatch to.");
             _deviceIndex = deviceIndex;
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _logger = logger ?? throw new ArgumentNullException(
+                nameof(logger),
+                $"ILogger is required for DeviceWorkScheduler (deviceIndex={deviceIndex}). Pass a non-null logger to capture queue and stealing diagnostics.");
             _workQueue = new ConcurrentQueue<WorkItem<T>>();
             _workAvailable = new SemaphoreSlim(0);
             _statistics = new DeviceQueueStatistics

--- a/src/Core/DotCompute.Core/Execution/ExecutionCoordinator.cs
+++ b/src/Core/DotCompute.Core/Execution/ExecutionCoordinator.cs
@@ -103,7 +103,9 @@ namespace DotCompute.Core.Execution
         private static void LogCoordinatorDisposed(ILogger logger)
             => _logCoordinatorDisposed(logger, null);
 
-        private readonly ILogger _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        private readonly ILogger _logger = logger ?? throw new ArgumentNullException(
+            nameof(logger),
+            "ILogger is required for execution coordination diagnostics. Pass a non-null logger from ILoggerFactory.");
         private readonly ConcurrentDictionary<string, ExecutionEvent> _events = new();
         private readonly ConcurrentDictionary<string, ExecutionBarrier> _barriers = new();
         private readonly SemaphoreSlim _coordinationSemaphore = new(1);
@@ -296,13 +298,17 @@ namespace DotCompute.Core.Execution
         private static void LogExecutionEventReset(ILogger logger, string eventName)
             => _logExecutionEventReset(logger, eventName, null);
 
-        private readonly ILogger _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        private readonly ILogger _logger = logger ?? throw new ArgumentNullException(
+            nameof(logger),
+            "ILogger is required for execution coordination diagnostics. Pass a non-null logger from ILoggerFactory.");
         private readonly SemaphoreSlim _semaphore = new(0);
         private volatile bool _isSignaled;
         private bool _disposed;
 
         /// <summary>Gets the event name.</summary>
-        public string Name { get; } = name ?? throw new ArgumentNullException(nameof(name));
+        public string Name { get; } = name ?? throw new ArgumentNullException(
+            nameof(name),
+            "ExecutionCoordinator primitives (ExecutionEvent / ExecutionBarrier) require a non-null name for lookup and diagnostics. Pass a unique identifier, e.g., \"stage-1-barrier\".");
 
         /// <summary>Gets whether the event has been signaled.</summary>
         public bool IsSignaled => _isSignaled;
@@ -416,7 +422,9 @@ namespace DotCompute.Core.Execution
         private static void LogExecutionBarrierReset(ILogger logger, string barrierName)
             => _logExecutionBarrierReset(logger, barrierName, null);
 
-        private readonly ILogger _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        private readonly ILogger _logger = logger ?? throw new ArgumentNullException(
+            nameof(logger),
+            "ILogger is required for execution coordination diagnostics. Pass a non-null logger from ILoggerFactory.");
         private readonly int _participantCount = participantCount;
         private readonly SemaphoreSlim _entrySemaphore = new(0);
         private volatile int _participantsEntered;
@@ -424,7 +432,9 @@ namespace DotCompute.Core.Execution
         private bool _disposed;
 
         /// <summary>Gets the barrier name.</summary>
-        public string Name { get; } = name ?? throw new ArgumentNullException(nameof(name));
+        public string Name { get; } = name ?? throw new ArgumentNullException(
+            nameof(name),
+            "ExecutionCoordinator primitives (ExecutionEvent / ExecutionBarrier) require a non-null name for lookup and diagnostics. Pass a unique identifier, e.g., \"stage-1-barrier\".");
 
         /// <summary>Gets the number of participants required.</summary>
         public int ParticipantCount => _participantCount;

--- a/src/Core/DotCompute.Core/Execution/ExecutionPlanExecutor.cs
+++ b/src/Core/DotCompute.Core/Execution/ExecutionPlanExecutor.cs
@@ -226,10 +226,14 @@ namespace DotCompute.Core.Execution
         private static void LogExecutorDisposed(ILogger logger)
             => _logExecutorDisposed(logger, null);
 
-        private readonly ILogger _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        private readonly ILogger _logger = logger ?? throw new ArgumentNullException(
+            nameof(logger),
+            "ILogger is required for ExecutionPlanExecutor. Pass a logger resolved from ILoggerFactory.");
         private readonly ExecutionCoordinator _coordinator = new(logger);
 #pragma warning disable CA2213 // Disposable fields should be disposed - Injected dependency, not owned by this class
-        private readonly PerformanceMonitor _performanceMonitor = performanceMonitor ?? throw new ArgumentNullException(nameof(performanceMonitor));
+        private readonly PerformanceMonitor _performanceMonitor = performanceMonitor ?? throw new ArgumentNullException(
+            nameof(performanceMonitor),
+            "PerformanceMonitor is required for ExecutionPlanExecutor to track strategy-level metrics. Construct and share a PerformanceMonitor across executors or resolve via DI.");
 #pragma warning restore CA2213
         private readonly ResourceTracker _resourceTracker = new(logger);
         private readonly ExecutionProfiler _profiler = new(logger);

--- a/src/Core/DotCompute.Core/Execution/ExecutionPlanFactory.cs
+++ b/src/Core/DotCompute.Core/Execution/ExecutionPlanFactory.cs
@@ -38,7 +38,9 @@ namespace DotCompute.Core.Execution
 
         private readonly ExecutionPlanGenerator _generator = new(logger);
         private readonly ExecutionPlanOptimizer _optimizer = new(logger, performanceMonitor);
-        private readonly ILogger _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        private readonly ILogger _logger = logger ?? throw new ArgumentNullException(
+            nameof(logger),
+            "ILogger is required for ExecutionPlanFactory to emit plan-generation diagnostics. Pass a non-null logger (e.g., via DI or ILoggerFactory.CreateLogger<ExecutionPlanFactory>()).");
 
         /// <summary>
         /// Creates an optimal execution plan based on workload characteristics and available resources.
@@ -226,7 +228,9 @@ namespace DotCompute.Core.Execution
             CancellationToken cancellationToken) where T : unmanaged
         {
             var dataParallelWorkload = workload as DataParallelWorkload<T> ??
-                throw new ArgumentException("Workload must be DataParallelWorkload for data parallel execution");
+                throw new ArgumentException(
+                    $"Data-parallel execution requires a DataParallelWorkload<{typeof(T).Name}>, but received a {workload.GetType().Name} (WorkloadType={workload.WorkloadType}). Either wrap the workload as DataParallelWorkload or change the execution strategy.",
+                    nameof(workload));
 
             var options = new DataParallelismOptions
             {
@@ -256,7 +260,9 @@ namespace DotCompute.Core.Execution
             CancellationToken cancellationToken) where T : unmanaged
         {
             var modelWorkload = workload as ModelParallelWorkload<T> ??
-                throw new ArgumentException("Workload must be ModelParallelWorkload for model parallel execution");
+                throw new ArgumentException(
+                    $"Model-parallel execution requires a ModelParallelWorkload<{typeof(T).Name}>, but received a {workload.GetType().Name} (WorkloadType={workload.WorkloadType}). Either wrap the workload as ModelParallelWorkload (with layer definitions) or choose a different strategy.",
+                    nameof(workload));
 
             var options = new ModelParallelismOptions
             {
@@ -278,7 +284,9 @@ namespace DotCompute.Core.Execution
             CancellationToken cancellationToken) where T : unmanaged
         {
             var pipelineWorkload = workload as PipelineWorkload<T> ??
-                throw new ArgumentException("Workload must be PipelineWorkload for pipeline execution");
+                throw new ArgumentException(
+                    $"Pipeline execution requires a PipelineWorkload<{typeof(T).Name}>, but received a {workload.GetType().Name} (WorkloadType={workload.WorkloadType}). Either wrap the workload as PipelineWorkload (with stage definitions) or choose a different strategy.",
+                    nameof(workload));
 
             var options = new PipelineParallelismOptions
             {
@@ -335,7 +343,9 @@ namespace DotCompute.Core.Execution
                     cancellationToken);
             }
 
-            throw new NotSupportedException($"Single device execution not supported for workload type {workload.WorkloadType}");
+            throw new NotSupportedException(
+                $"GenerateSingleDevicePlanAsync only supports DataParallelWorkload, but received a {workload.GetType().Name} with WorkloadType={workload.WorkloadType}. " +
+                $"Use CreateOptimalPlanAsync to automatically select a multi-device strategy, or wrap your workload as DataParallelWorkload<{typeof(T).Name}>.");
         }
 
         /// <summary>

--- a/src/Core/DotCompute.Core/Execution/ExecutionPlanGenerator.cs
+++ b/src/Core/DotCompute.Core/Execution/ExecutionPlanGenerator.cs
@@ -31,7 +31,9 @@ namespace DotCompute.Core.Execution
     /// <exception cref="ArgumentNullException">Thrown when required parameters are null</exception>
     public sealed class ExecutionPlanGenerator(ILogger logger)
     {
-        private readonly ILogger _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        private readonly ILogger _logger = logger ?? throw new ArgumentNullException(
+            nameof(logger),
+            "ILogger is required for ExecutionPlanGenerator. Pass a non-null logger from ILoggerFactory so strategy/plan generation emits diagnostics.");
         private readonly DependencyAnalyzer _dependencyAnalyzer = new(logger);
         private readonly ResourceScheduler _resourceScheduler = new(logger);
         private readonly ExecutionOptimizer _executionOptimizer = new(logger);
@@ -614,7 +616,8 @@ namespace DotCompute.Core.Execution
         {
             if (visiting.Contains(layerId))
             {
-                throw new InvalidOperationException("Circular dependency detected in model layers");
+                throw new InvalidOperationException(
+                    $"Circular dependency detected in ModelLayer<{typeof(T).Name}> at layer id {layerId}. Topological sort requires a DAG — break the cycle in layer dependencies before generating a model-parallel execution plan.");
             }
 
             if (visited.Contains(layerId))

--- a/src/Core/DotCompute.Core/Execution/LoadBalancer.cs
+++ b/src/Core/DotCompute.Core/Execution/LoadBalancer.cs
@@ -36,8 +36,12 @@ namespace DotCompute.Core.Execution
         /// </exception>
         public LoadBalancer(IAccelerator[] devices, ILogger logger)
         {
-            _devices = devices ?? throw new ArgumentNullException(nameof(devices));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _devices = devices ?? throw new ArgumentNullException(
+                nameof(devices),
+                "LoadBalancer requires the device array to schedule work across. Pass the IAccelerator[] the parallel strategy is targeting.");
+            _logger = logger ?? throw new ArgumentNullException(
+                nameof(logger),
+                "ILogger is required for LoadBalancer distribution diagnostics. Pass a non-null logger.");
         }
 
         /// <summary>
@@ -55,7 +59,9 @@ namespace DotCompute.Core.Execution
             if (deviceQueues == null || deviceQueues.Length == 0)
             {
                 LogNoDeviceSchedulers(_logger);
-                throw new ArgumentException("Device schedulers cannot be null or empty", nameof(deviceQueues));
+                throw new ArgumentException(
+                    $"LoadBalancer.DistributeWorkItems requires at least one DeviceWorkScheduler (received {(deviceQueues is null ? "null" : "0")}). Construct a scheduler per target device before distributing.",
+                    nameof(deviceQueues));
             }
 
             var validWorkItems = workItems.Where(item => item != null).ToList();

--- a/src/Core/DotCompute.Core/Execution/ManagedCompiledKernel.cs
+++ b/src/Core/DotCompute.Core/Execution/ManagedCompiledKernel.cs
@@ -30,13 +30,17 @@ public sealed class ManagedCompiledKernel(string name, IAccelerator device, Comp
     /// Gets the kernel name.
     /// </summary>
     /// <value>The unique name identifier for this kernel.</value>
-    public string Name { get; } = name ?? throw new ArgumentNullException(nameof(name));
+    public string Name { get; } = name ?? throw new ArgumentNullException(
+        nameof(name),
+        "ManagedCompiledKernel requires a non-null kernel name — this identifier links the wrapped kernel to its compilation entry in the kernel cache.");
 
     /// <summary>
     /// Gets the target device.
     /// </summary>
     /// <value>The accelerator device this kernel was compiled for.</value>
-    public IAccelerator Device { get; } = device ?? throw new ArgumentNullException(nameof(device));
+    public IAccelerator Device { get; } = device ?? throw new ArgumentNullException(
+        nameof(device),
+        "ManagedCompiledKernel requires the IAccelerator it was compiled for — execution statistics and dispatches are bound to a specific device.");
 
     /// <summary>
     /// Gets the compiled kernel wrapper.
@@ -93,7 +97,8 @@ public sealed class ManagedCompiledKernel(string name, IAccelerator device, Comp
     {
         if (executionTimeMs < 0)
         {
-            throw new ArgumentOutOfRangeException(nameof(executionTimeMs), "Execution time cannot be negative");
+            throw new ArgumentOutOfRangeException(nameof(executionTimeMs), executionTimeMs,
+                $"RecordExecution requires a non-negative duration (got {executionTimeMs} ms for kernel '{Name}'). Record zero for near-instant kernels instead of a sentinel negative value.");
         }
 
         _ = Interlocked.Increment(ref _executionCount);

--- a/src/Core/DotCompute.Core/Execution/Memory/DeviceBufferPool.cs
+++ b/src/Core/DotCompute.Core/Execution/Memory/DeviceBufferPool.cs
@@ -23,7 +23,9 @@ namespace DotCompute.Core.Execution.Memory
     /// <exception cref="ArgumentNullException">Thrown when deviceId is null.</exception>
     public sealed class DeviceBufferPool(string deviceId) : IAsyncDisposable
     {
-        private readonly string _deviceId = deviceId ?? throw new ArgumentNullException(nameof(deviceId));
+        private readonly string _deviceId = deviceId ?? throw new ArgumentNullException(
+            nameof(deviceId),
+            "DeviceBufferPool requires a non-null device ID — this identifier (typically IAccelerator.Info.Id) labels pool metrics and routes buffers to the correct device.");
         private readonly ConcurrentQueue<IUnifiedMemoryBuffer> _availableBuffers = new();
         private readonly ConcurrentDictionary<long, int> _allocationSizes = new();
         private long _totalAllocated;

--- a/src/Core/DotCompute.Core/Execution/Memory/ExecutionMemoryManager.cs
+++ b/src/Core/DotCompute.Core/Execution/Memory/ExecutionMemoryManager.cs
@@ -43,7 +43,9 @@ namespace DotCompute.Core.Execution.Memory
                 var buffer = await pool.AllocateBufferAsync(request.SizeInBytes, request.Options, cancellationToken);
                 // IUnifiedMemoryBuffer<T> inherits from IUnifiedMemoryBuffer
                 // So we can safely cast and add to the non-generic list
-                buffers.Add(buffer as AbstractionsMemory.IUnifiedMemoryBuffer ?? throw new InvalidCastException("Buffer must implement IUnifiedMemoryBuffer"));
+                buffers.Add(buffer as AbstractionsMemory.IUnifiedMemoryBuffer ?? throw new InvalidCastException(
+                    $"Buffer allocated by DeviceBufferPool('{request.DeviceId}') is of type {buffer.GetType().FullName} which does not implement AbstractionsMemory.IUnifiedMemoryBuffer. " +
+                    $"The buffer must implement the non-generic IUnifiedMemoryBuffer interface (all IUnifiedMemoryBuffer<T> inherit from it) — check the pool's AllocateBufferAsync implementation."));
             }
 
             _executionBuffers[executionId] = buffers;

--- a/src/Core/DotCompute.Core/Execution/Memory/MemoryBuffer.cs
+++ b/src/Core/DotCompute.Core/Execution/Memory/MemoryBuffer.cs
@@ -34,7 +34,8 @@ internal sealed class MemoryBuffer : IUnifiedMemoryBuffer<byte>
         if (sizeInBytes > int.MaxValue)
         {
 
-            throw new ArgumentOutOfRangeException(nameof(sizeInBytes), "Size exceeds maximum array size");
+            throw new ArgumentOutOfRangeException(nameof(sizeInBytes), sizeInBytes,
+                $"Execution MemoryBuffer is backed by a managed byte[] and cannot exceed int.MaxValue ({int.MaxValue:N0}) bytes; received {sizeInBytes:N0}. For larger allocations use IMemoryManager.AllocateAsync directly on an IAccelerator which supports 64-bit buffers.");
         }
 
 
@@ -125,7 +126,8 @@ internal sealed class MemoryBuffer : IUnifiedMemoryBuffer<byte>
 
     public MappedMemory<byte> Map(MapMode mode = MapMode.ReadWrite)
 
-        => throw new NotSupportedException("Memory mapping not supported");
+        => throw new NotSupportedException(
+            "Execution MemoryBuffer is a host-only byte array and does not support Map/Unmap — use AsSpan(), AsMemory(), or AsReadOnlySpan() for direct zero-copy host access.");
     /// <summary>
     /// Gets map range.
     /// </summary>
@@ -136,7 +138,8 @@ internal sealed class MemoryBuffer : IUnifiedMemoryBuffer<byte>
 
 
     public MappedMemory<byte> MapRange(int offset, int length, MapMode mode = MapMode.ReadWrite)
-        => throw new NotSupportedException("Memory mapping not supported");
+        => throw new NotSupportedException(
+            "Execution MemoryBuffer is a host-only byte array and does not support MapRange — use AsSpan(offset, length) or AsMemory().Slice(offset, length) instead.");
     /// <summary>
     /// Gets map asynchronously.
     /// </summary>
@@ -146,7 +149,8 @@ internal sealed class MemoryBuffer : IUnifiedMemoryBuffer<byte>
 
 
     public ValueTask<MappedMemory<byte>> MapAsync(MapMode mode = MapMode.ReadWrite, CancellationToken cancellationToken = default)
-        => throw new NotSupportedException("Memory mapping not supported");
+        => throw new NotSupportedException(
+            "Execution MemoryBuffer is a host-only byte array and does not support MapAsync — use AsMemory() for direct zero-copy host access, or copy to/from an accelerator-backed IUnifiedMemoryBuffer that supports mapping.");
     /// <summary>
     /// Performs ensure on host.
     /// </summary>
@@ -278,7 +282,8 @@ internal sealed class MemoryBuffer : IUnifiedMemoryBuffer<byte>
     /// <returns>The result of the operation.</returns>
 
     public IUnifiedMemoryBuffer<byte> Slice(int offset, int length)
-        => throw new NotSupportedException("Slicing not supported");
+        => throw new NotSupportedException(
+            $"Execution MemoryBuffer does not support Slice() into a sub-buffer (requested offset={offset}, length={length} on a buffer of {SizeInBytes:N0} bytes). Use AsMemory(offset, length) for a host-side view, or allocate a new buffer through an IMemoryManager that supports slicing.");
     /// <summary>
     /// Gets as type.
     /// </summary>
@@ -286,7 +291,8 @@ internal sealed class MemoryBuffer : IUnifiedMemoryBuffer<byte>
     /// <returns>The result of the operation.</returns>
 
     public IUnifiedMemoryBuffer<TNew> AsType<TNew>() where TNew : unmanaged
-        => throw new NotSupportedException("Type conversion not supported");
+        => throw new NotSupportedException(
+            $"Execution MemoryBuffer does not support AsType<{typeof(TNew).Name}>() type-reinterpretation from byte. Use MemoryMarshal.Cast<byte, {typeof(TNew).Name}>(AsSpan()) on the host side, or allocate a typed buffer directly via IMemoryManager.AllocateAsync<{typeof(TNew).Name}>.");
     /// <summary>
     /// Performs dispose.
     /// </summary>

--- a/src/Core/DotCompute.Core/Execution/Metrics/DeviceMetrics.cs
+++ b/src/Core/DotCompute.Core/Execution/Metrics/DeviceMetrics.cs
@@ -185,9 +185,8 @@ namespace DotCompute.Core.Execution.Metrics
         {
             if (utilizationPercentage is < 0.0 or > 100.0)
             {
-                throw new ArgumentOutOfRangeException(nameof(utilizationPercentage),
-
-                    "Utilization percentage must be between 0 and 100.");
+                throw new ArgumentOutOfRangeException(nameof(utilizationPercentage), utilizationPercentage,
+                    $"Device utilization must be in [0, 100] (received {utilizationPercentage:F2}%). If the caller expresses utilization as a fraction, multiply by 100 before passing.");
             }
 
             UtilizationPercentage = utilizationPercentage;

--- a/src/Core/DotCompute.Core/Execution/Metrics/ExecutionStrategyRecommendation.cs
+++ b/src/Core/DotCompute.Core/Execution/Metrics/ExecutionStrategyRecommendation.cs
@@ -246,14 +246,15 @@ namespace DotCompute.Core.Execution.Metrics
         {
             if (ConfidenceScore is < 0.0 or > 1.0)
             {
-                throw new ArgumentOutOfRangeException(nameof(ConfidenceScore),
-
-                    "Confidence score must be between 0.0 and 1.0.");
+                throw new ArgumentOutOfRangeException(nameof(ConfidenceScore), ConfidenceScore,
+                    $"ExecutionStrategyRecommendation.ConfidenceScore must be in [0.0, 1.0] — a unit interval where 0 = no confidence and 1 = certain (received {ConfidenceScore:F4}). Normalise the score to that range before calling Validate().");
             }
 
             if (string.IsNullOrWhiteSpace(Reasoning))
             {
-                throw new ArgumentException("Reasoning cannot be null or whitespace.", nameof(Reasoning));
+                throw new ArgumentException(
+                    "ExecutionStrategyRecommendation.Reasoning must be a non-empty human-readable explanation (for logs/diagnostics). Describe the factors that drove the recommendation.",
+                    nameof(Reasoning));
             }
         }
 

--- a/src/Core/DotCompute.Core/Execution/Metrics/ParallelExecutionAnalysis.cs
+++ b/src/Core/DotCompute.Core/Execution/Metrics/ParallelExecutionAnalysis.cs
@@ -178,7 +178,9 @@ namespace DotCompute.Core.Execution.Metrics
         {
             if (string.IsNullOrWhiteSpace(recommendation))
             {
-                throw new ArgumentException("Recommendation cannot be null or whitespace.", nameof(recommendation));
+                throw new ArgumentException(
+                    "AddRecommendation requires a non-empty human-readable recommendation string (it appears in analysis reports). Describe the suggested action, e.g., 'Increase local work size to improve occupancy'.",
+                    nameof(recommendation));
             }
 
 
@@ -196,15 +198,16 @@ namespace DotCompute.Core.Execution.Metrics
         {
             if (string.IsNullOrWhiteSpace(deviceId))
             {
-                throw new ArgumentException("Device ID cannot be null or whitespace.", nameof(deviceId));
+                throw new ArgumentException(
+                    $"Device ID for UpdateDeviceUtilization must be a non-empty string (received '{deviceId ?? "<null>"}'). Pass IAccelerator.Info.Id of the device you are recording utilization for.",
+                    nameof(deviceId));
             }
 
 
             if (utilization is < 0.0 or > 100.0)
             {
-                throw new ArgumentOutOfRangeException(nameof(utilization),
-
-                    "Utilization must be between 0 and 100.");
+                throw new ArgumentOutOfRangeException(nameof(utilization), utilization,
+                    $"Utilization for device '{deviceId}' must be in [0, 100] (received {utilization:F2}%). If you have a 0..1 fraction, multiply by 100 before passing.");
             }
 
 

--- a/src/Core/DotCompute.Core/Execution/Optimization/ExecutionOptimizer.cs
+++ b/src/Core/DotCompute.Core/Execution/Optimization/ExecutionOptimizer.cs
@@ -19,7 +19,9 @@ namespace DotCompute.Core.Execution.Optimization
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="logger"/> is null.</exception>
     public sealed partial class ExecutionOptimizer(ILogger logger)
     {
-        private readonly ILogger _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        private readonly ILogger _logger = logger ?? throw new ArgumentNullException(
+            nameof(logger),
+            "ILogger is required for ExecutionOptimizer. Pass a non-null logger from ILoggerFactory to capture strategy-specific optimization diagnostics.");
 
         #region LoggerMessage Delegates - Event ID range 23300-23315
 

--- a/src/Core/DotCompute.Core/Execution/Optimization/ExecutionPlanOptimizer.cs
+++ b/src/Core/DotCompute.Core/Execution/Optimization/ExecutionPlanOptimizer.cs
@@ -24,8 +24,12 @@ namespace DotCompute.Core.Execution.Optimization
     /// </exception>
     public sealed partial class ExecutionPlanOptimizer(ILogger logger, PerformanceMonitor performanceMonitor)
     {
-        private readonly ILogger _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        private readonly PerformanceMonitor _performanceMonitor = performanceMonitor ?? throw new ArgumentNullException(nameof(performanceMonitor));
+        private readonly ILogger _logger = logger ?? throw new ArgumentNullException(
+            nameof(logger),
+            "ILogger is required for ExecutionPlanOptimizer. Pass a non-null logger to capture optimization-pass diagnostics.");
+        private readonly PerformanceMonitor _performanceMonitor = performanceMonitor ?? throw new ArgumentNullException(
+            nameof(performanceMonitor),
+            "PerformanceMonitor is required for ExecutionPlanOptimizer to read device/kernel history that informs optimization decisions. Share a PerformanceMonitor across optimizer and executor.");
 
         /// <summary>
         /// Applies cross-cutting optimizations to any execution plan.

--- a/src/Core/DotCompute.Core/Execution/ParallelExecutionStrategy.cs
+++ b/src/Core/DotCompute.Core/Execution/ParallelExecutionStrategy.cs
@@ -127,9 +127,15 @@ namespace DotCompute.Core.Execution
             IKernelManager kernelManager,
             ILoggerFactory? loggerFactory = null)
         {
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _acceleratorManager = acceleratorManager ?? throw new ArgumentNullException(nameof(acceleratorManager));
-            _kernelManager = kernelManager ?? throw new ArgumentNullException(nameof(kernelManager));
+            _logger = logger ?? throw new ArgumentNullException(
+                nameof(logger),
+                "ILogger<ParallelExecutionStrategy> is required. Register logging in DI via AddLogging() before resolving this service.");
+            _acceleratorManager = acceleratorManager ?? throw new ArgumentNullException(
+                nameof(acceleratorManager),
+                "IAcceleratorManager is required for ParallelExecutionStrategy. Register it with AddDotComputeRuntime() so the strategy can enumerate and assign devices.");
+            _kernelManager = kernelManager ?? throw new ArgumentNullException(
+                nameof(kernelManager),
+                "IKernelManager is required for ParallelExecutionStrategy. Register it with AddDotComputeRuntime() — the strategy compiles and caches kernels per-device through this service.");
             _loggerFactory = loggerFactory ?? new NullLoggerFactory();
 
             // Memory manager is bound lazily from the AcceleratorManager at execution time,
@@ -493,17 +499,23 @@ namespace DotCompute.Core.Execution
         {
             if (inputBuffers == null || inputBuffers.Length == 0)
             {
-                throw new ArgumentException("Input buffers cannot be null or empty", nameof(inputBuffers));
+                throw new ArgumentException(
+                    $"Data-parallel execution requires at least one input buffer (received {(inputBuffers is null ? "null" : "0")}). Pass the input IUnifiedMemoryBuffer<{typeof(T).Name}> array that the kernel will read from.",
+                    nameof(inputBuffers));
             }
 
             if (outputBuffers == null || outputBuffers.Length == 0)
             {
-                throw new ArgumentException("Output buffers cannot be null or empty", nameof(outputBuffers));
+                throw new ArgumentException(
+                    $"Data-parallel execution requires at least one output buffer (received {(outputBuffers is null ? "null" : "0")}). Pre-allocate output IUnifiedMemoryBuffer<{typeof(T).Name}> with IMemoryManager.AllocateAsync before calling ExecuteDataParallelAsync.",
+                    nameof(outputBuffers));
             }
 
             if (devices == null || devices.Length == 0)
             {
-                throw new ArgumentException("No devices available for execution", nameof(devices));
+                throw new ArgumentException(
+                    $"Data-parallel execution requires at least one device (received {(devices is null ? "null" : "0")}). Either pass specific IAccelerator instances, or let ParallelExecutionStrategy auto-select via IAcceleratorManager.",
+                    nameof(devices));
             }
 
             // Validate buffer sizes are divisible by device count for even distribution
@@ -842,7 +854,10 @@ namespace DotCompute.Core.Execution
 
             if (devices.Length < pipeline.Stages.Count)
             {
-                throw new ArgumentException($"Need at least {pipeline.Stages.Count} devices for pipeline stages");
+                throw new ArgumentException(
+                    $"Pipeline-parallel execution needs at least one device per stage: pipeline has {pipeline.Stages.Count} stages but only {devices.Length} device(s) were provided. " +
+                    $"Supply {pipeline.Stages.Count - devices.Length} more devices, reduce pipeline stage count, or use a different parallelism strategy.",
+                    nameof(devices));
             }
 
             // Create pipeline stages with compiled kernels
@@ -980,7 +995,9 @@ namespace DotCompute.Core.Execution
 
             public ManagedCompiledKernelAdapter(ManagedCompiledKernel inner)
             {
-                _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+                _inner = inner ?? throw new ArgumentNullException(
+                    nameof(inner),
+                    "ManagedCompiledKernelAdapter requires the execution-layer ManagedCompiledKernel it adapts — cannot forward calls to a null kernel.");
             }
 
             public override string Name => _inner.Name;

--- a/src/Core/DotCompute.Core/Execution/PerformanceAnalyzer.cs
+++ b/src/Core/DotCompute.Core/Execution/PerformanceAnalyzer.cs
@@ -22,7 +22,9 @@ public class PerformanceAnalyzer
     /// <param name="logger">The logger.</param>
     public PerformanceAnalyzer(ILogger logger)
     {
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _logger = logger ?? throw new ArgumentNullException(
+            nameof(logger),
+            "ILogger is required for PerformanceAnalyzer. Pass a non-null logger from ILoggerFactory to capture analysis diagnostics.");
     }
     /// <summary>
     /// Gets analyze performance.

--- a/src/Core/DotCompute.Core/Execution/PerformanceMonitor.cs
+++ b/src/Core/DotCompute.Core/Execution/PerformanceMonitor.cs
@@ -28,7 +28,9 @@ namespace DotCompute.Core.Execution
 
         #endregion
 
-        private readonly ILogger _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        private readonly ILogger _logger = logger ?? throw new ArgumentNullException(
+            nameof(logger),
+            "ILogger is required for PerformanceMonitor. Pass a non-null logger from ILoggerFactory to capture kernel/device performance data.");
         private readonly ConcurrentQueue<ExecutionRecord> _executionHistory = new();
         private readonly ConcurrentDictionary<string, KernelPerformanceProfile> _kernelProfiles = new();
         private readonly ConcurrentDictionary<string, DevicePerformanceProfile> _deviceProfiles = new();

--- a/src/Core/DotCompute.Core/Execution/Scheduling/ResourceScheduler.cs
+++ b/src/Core/DotCompute.Core/Execution/Scheduling/ResourceScheduler.cs
@@ -22,7 +22,9 @@ namespace DotCompute.Core.Execution.Scheduling
     /// <exception cref="ArgumentNullException">Thrown when logger is null</exception>
     public sealed class ResourceScheduler(ILogger logger)
     {
-        private readonly ILogger _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        private readonly ILogger _logger = logger ?? throw new ArgumentNullException(
+            nameof(logger),
+            "ILogger is required for ResourceScheduler to emit device-selection and workload-distribution diagnostics. Pass a non-null logger (e.g., from ILoggerFactory.CreateLogger<ResourceScheduler>()).");
         private readonly DevicePerformanceEstimator _performanceEstimator = new();
         private static readonly DevicePerformanceEstimator _staticPerformanceEstimator = new();
 
@@ -54,7 +56,10 @@ namespace DotCompute.Core.Execution.Scheduling
 
                 if (deviceCandidates.Count == 0)
                 {
-                    throw new InvalidOperationException("No available devices match the target device list");
+                    var targetIds = string.Join(", ", options.TargetDevices);
+                    var availableIds = string.Join(", ", availableDevices.Select(d => d.Info.Id));
+                    throw new InvalidOperationException(
+                        $"No available devices match DataParallelismOptions.TargetDevices. Requested: [{targetIds}]; Available: [{availableIds}]. Check device IDs match exactly, or clear TargetDevices to let the scheduler choose automatically.");
                 }
             }
 
@@ -79,7 +84,8 @@ namespace DotCompute.Core.Execution.Scheduling
 
             if (selectedDevices.Length == 0)
             {
-                throw new InvalidOperationException("No suitable devices available for execution");
+                throw new InvalidOperationException(
+                    $"ResourceScheduler scored {deviceCandidates.Count} device(s) but none qualified for execution (all received a zero/negative score). Ensure at least one accelerator is running, check per-device diagnostics in the accelerator manager, or relax DataParallelismOptions constraints.");
             }
 
             _logger.LogInfoMessage($"Selected {selectedDevices.Length} optimal devices from {availableDevices.Length} available");
@@ -110,7 +116,9 @@ namespace DotCompute.Core.Execution.Scheduling
 
             if (devices.Length == 0)
             {
-                throw new ArgumentException("At least one device must be provided", nameof(devices));
+                throw new ArgumentException(
+                    "ResourceScheduler requires at least one target device for workload distribution (received empty array). Obtain devices via IAcceleratorManager.GetAvailableAcceleratorsAsync() or pass a specific IAccelerator instance.",
+                    nameof(devices));
             }
 
             var totalElements = inputBuffers.Sum(b => (int)b.Length);
@@ -160,12 +168,16 @@ namespace DotCompute.Core.Execution.Scheduling
 
             if (layers.Count == 0)
             {
-                throw new ArgumentException("At least one layer must be provided", nameof(layers));
+                throw new ArgumentException(
+                    $"Model-parallel execution needs at least one model layer (received empty list). Populate ModelDefinition<{typeof(T).Name}>.Layers before calling ExecuteModelParallelAsync.",
+                    nameof(layers));
             }
 
             if (devices.Length == 0)
             {
-                throw new ArgumentException("At least one device must be provided", nameof(devices));
+                throw new ArgumentException(
+                    "ResourceScheduler requires at least one target device for workload distribution (received empty array). Obtain devices via IAcceleratorManager.GetAvailableAcceleratorsAsync() or pass a specific IAccelerator instance.",
+                    nameof(devices));
             }
 
             _ = new Dictionary<int, IAccelerator>();
@@ -207,12 +219,16 @@ namespace DotCompute.Core.Execution.Scheduling
 
             if (stages.Count == 0)
             {
-                throw new ArgumentException("At least one stage must be provided", nameof(stages));
+                throw new ArgumentException(
+                    "Pipeline-parallel execution needs at least one PipelineStageDefinition (received empty list). Populate PipelineDefinition.Stages before calling AssignStagesToDevicesAsync.",
+                    nameof(stages));
             }
 
             if (devices.Length == 0)
             {
-                throw new ArgumentException("At least one device must be provided", nameof(devices));
+                throw new ArgumentException(
+                    "ResourceScheduler requires at least one target device for workload distribution (received empty array). Obtain devices via IAcceleratorManager.GetAvailableAcceleratorsAsync() or pass a specific IAccelerator instance.",
+                    nameof(devices));
             }
 
             await Task.CompletedTask.ConfigureAwait(false);

--- a/src/Core/DotCompute.Core/Execution/StealingCoordinator.cs
+++ b/src/Core/DotCompute.Core/Execution/StealingCoordinator.cs
@@ -26,7 +26,9 @@ namespace DotCompute.Core.Execution
         public StealingCoordinator(int deviceCount, ILogger logger)
         {
             _deviceCount = deviceCount;
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _logger = logger ?? throw new ArgumentNullException(
+                nameof(logger),
+                $"ILogger is required for StealingCoordinator(deviceCount={deviceCount}). Pass a logger to capture work-stealing decisions and per-device statistics.");
 
             // Initialize jagged arrays instead of multidimensional
             _successfulSteals = new int[deviceCount][];

--- a/src/Core/DotCompute.Core/Execution/WorkStealingCoordinator.cs
+++ b/src/Core/DotCompute.Core/Execution/WorkStealingCoordinator.cs
@@ -217,7 +217,9 @@ namespace DotCompute.Core.Execution
             catch (Exception ex)
             {
                 _logger.LogErrorMessage(ex, "Failed to distribute work items during initialization");
-                throw new InvalidOperationException("Failed to initialize work items for work stealing execution", ex);
+                throw new InvalidOperationException(
+                    $"Failed to initialize {_workload.WorkItems.Count} work items across {_devices.Length} device(s) for work-stealing execution. See inner exception for the distribution failure. Verify each device queue has capacity and that the load balancer's strategy is compatible with the workload shape.",
+                    ex);
             }
         }
 
@@ -526,7 +528,8 @@ namespace DotCompute.Core.Execution
                 // Validate work item has valid buffers before execution
                 if (workItem.InputBuffers == null || workItem.OutputBuffers == null)
                 {
-                    throw new InvalidOperationException($"Work item {workItem.Id} has null buffers");
+                    throw new InvalidOperationException(
+                        $"Work item {workItem.Id} (assigned to device {device.Info.Id}) has null InputBuffers or OutputBuffers and cannot be executed. Populate both buffer collections on the WorkItem before adding it to the WorkStealingWorkload.");
                 }
 
                 // Check for cancellation before expensive operations
@@ -584,7 +587,9 @@ namespace DotCompute.Core.Execution
 
                 if (!executionResult.Success)
                 {
-                    throw new InvalidOperationException($"Kernel execution failed: {executionResult.ErrorMessage}");
+                    throw new InvalidOperationException(
+                        $"Kernel execution failed for work item {workItem.Id} on device '{device.Info.Id}' ({device.Info.Name}): {executionResult.ErrorMessage ?? "<no error message>"}. " +
+                        $"Input buffers: {validInputBuffers.Length}, output buffers: {validOutputBuffers.Length}. Check the kernel's logs or enable diagnostic tracing for backend-level detail.");
                 }
 
                 var endTime = DateTimeOffset.UtcNow;

--- a/src/Core/DotCompute.Core/Pipelines/KernelChain.cs
+++ b/src/Core/DotCompute.Core/Pipelines/KernelChain.cs
@@ -25,7 +25,9 @@ namespace DotCompute.Core.Pipelines
         /// <param name="serviceProvider">The configured service provider containing DotCompute services</param>
         public static void Configure(IServiceProvider serviceProvider)
         {
-            _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+            _serviceProvider = serviceProvider ?? throw new ArgumentNullException(
+                nameof(serviceProvider),
+                "IServiceProvider is required to configure the static KernelChain. Pass the built provider (e.g., host.Services or builder.Services.BuildServiceProvider()) from application startup.");
             _logger = serviceProvider.GetService<ILogger<KernelChainBuilder>>();
         }
 

--- a/src/Core/DotCompute.Core/Pipelines/KernelChainBuilder.cs
+++ b/src/Core/DotCompute.Core/Pipelines/KernelChainBuilder.cs
@@ -220,7 +220,9 @@ namespace DotCompute.Core.Pipelines
 
         private static void LogDisposalError(ILogger logger, Exception ex)
             => _logDisposalError(logger, ex);
-        private readonly IComputeOrchestrator _orchestrator = orchestrator ?? throw new ArgumentNullException(nameof(orchestrator));
+        private readonly IComputeOrchestrator _orchestrator = orchestrator ?? throw new ArgumentNullException(
+            nameof(orchestrator),
+            "IComputeOrchestrator is required for KernelChainBuilder. Register the compute runtime with AddDotComputeRuntime() or resolve the orchestrator from the DI container before constructing the builder.");
         private readonly IKernelResolver? _kernelResolver = kernelResolver;
         private readonly IKernelChainProfiler? _profiler = profiler;
         private readonly IKernelChainValidator? _validator = validator;
@@ -247,7 +249,9 @@ namespace DotCompute.Core.Pipelines
             var step = new KernelChainStep
             {
                 Type = KernelChainStepType.Sequential,
-                KernelName = kernelName ?? throw new ArgumentNullException(nameof(kernelName)),
+                KernelName = kernelName ?? throw new ArgumentNullException(
+                    nameof(kernelName),
+                    "Kernel name is required when adding a sequential step to the kernel chain. Pass a registered kernel name (the one decorated with [Kernel]) or resolve it via IKernelResolver."),
                 Arguments = args ?? [],
                 StepId = Guid.NewGuid().ToString(),
                 ExecutionOrder = _steps.Count
@@ -276,7 +280,9 @@ namespace DotCompute.Core.Pipelines
             if (kernels == null || kernels.Length == 0)
             {
 
-                throw new ArgumentException("At least one kernel must be specified for parallel execution", nameof(kernels));
+                throw new ArgumentException(
+                    $"Parallel kernel execution requires at least one kernel; received {(kernels?.Length ?? 0)}. Pass one or more (kernelName, args) tuples to Parallel(...), or use Kernel(...) for single-kernel execution.",
+                    nameof(kernels));
             }
 
 
@@ -356,14 +362,17 @@ namespace DotCompute.Core.Pipelines
             if (string.IsNullOrWhiteSpace(key))
             {
 
-                throw new ArgumentException("Cache key cannot be null or whitespace", nameof(key));
+                throw new ArgumentException(
+                    $"Cache key must be a non-empty, non-whitespace string; received '{key ?? "<null>"}'. Provide a stable key that uniquely identifies this step's inputs (e.g., include argument hashes).",
+                    nameof(key));
             }
 
 
             if (_steps.Count == 0)
             {
 
-                throw new InvalidOperationException("Cannot add caching to empty chain. Add a kernel step first.");
+                throw new InvalidOperationException(
+                    "Cannot attach Cache(...) to an empty kernel chain. Add at least one Kernel(name, ...) or Parallel(...) step before calling Cache(key, ttl) — caching applies to the last step added.");
             }
 
 
@@ -387,7 +396,9 @@ namespace DotCompute.Core.Pipelines
             if (string.IsNullOrWhiteSpace(backendName))
             {
 
-                throw new ArgumentException("Backend name cannot be null or whitespace", nameof(backendName));
+                throw new ArgumentException(
+                    $"Backend name must be a non-empty, non-whitespace string; received '{backendName ?? "<null>"}'. Use one of the registered backend names (e.g., \"CPU\", \"CUDA\", \"Metal\") or call OnAccelerator(IAccelerator) instead.",
+                    nameof(backendName));
             }
 
 
@@ -445,7 +456,9 @@ namespace DotCompute.Core.Pipelines
             if (timeout <= TimeSpan.Zero)
             {
 
-                throw new ArgumentException("Timeout must be positive", nameof(timeout));
+                throw new ArgumentException(
+                    $"Timeout must be a positive duration; received {timeout} (total={timeout.TotalMilliseconds:F2} ms). Pass a TimeSpan greater than zero, or omit WithTimeout(...) to run without a deadline.",
+                    nameof(timeout));
             }
 
 
@@ -527,7 +540,7 @@ namespace DotCompute.Core.Pipelines
             catch (Exception ex)
             {
                 throw new InvalidCastException(
-                    $"Cannot convert result of type {result.Result.GetType().Name} to {typeof(T).Name}", ex);
+                    $"Kernel chain execution returned a {result.Result.GetType().FullName} but ExecuteAsync<{typeof(T).Name}>() was called. Either change the generic argument to match the actual return type, or produce a {typeof(T).Name} in the final step. Inner IConvertible conversion failed with: {ex.Message}", ex);
             }
         }
 
@@ -538,7 +551,8 @@ namespace DotCompute.Core.Pipelines
 
             if (_steps.Count == 0)
             {
-                throw new InvalidOperationException("Cannot execute empty kernel chain. Add at least one kernel step.");
+                throw new InvalidOperationException(
+                    "Kernel chain has no steps — ExecuteWithMetricsAsync requires at least one step. Call Kernel(name, ...), Parallel(...), or Branch<T>(...) before ExecuteAsync/ExecuteWithMetricsAsync.");
             }
 
             var stopwatch = Stopwatch.StartNew();
@@ -557,7 +571,7 @@ namespace DotCompute.Core.Pipelines
                     {
                         var validationErrors = validation.Errors ?? [];
                         throw new InvalidOperationException(
-                            $"Kernel chain validation failed: {string.Join(", ", validationErrors)}");
+                            $"Kernel chain validation failed with {validationErrors.Count} error(s): {string.Join("; ", validationErrors)}. Fix the reported problems (e.g., missing kernel names, type mismatches between steps) or call WithValidation(false) to skip validation (not recommended for production).");
                     }
                 }
 
@@ -738,7 +752,8 @@ namespace DotCompute.Core.Pipelines
                         KernelChainStepType.Sequential => await ExecuteSequentialStepAsync(step, cancellationToken),
                         KernelChainStepType.Parallel => await ExecuteParallelStepAsync(step, cancellationToken),
                         KernelChainStepType.Branch => await ExecuteBranchStepAsync(step, previousResult, cancellationToken),
-                        _ => throw new NotSupportedException($"Step type {step.Type} is not supported")
+                        _ => throw new NotSupportedException(
+                            $"Kernel chain step type '{step.Type}' (id={step.StepId}) is not supported by the executor. Expected one of: Sequential, Parallel, Branch. This usually indicates a version mismatch or a new step type added without a corresponding executor case.")
                     };
 
                     // Cache result if configured
@@ -776,7 +791,8 @@ namespace DotCompute.Core.Pipelines
             if (string.IsNullOrEmpty(step.KernelName))
             {
 
-                throw new InvalidOperationException("Kernel name is required for sequential steps");
+                throw new InvalidOperationException(
+                    $"Sequential step {step.StepId} (order={step.ExecutionOrder}) has no kernel name. Sequential steps must reference a registered kernel by name — verify the step was added via Kernel(string, object[]) / Then(string, object[]) with a non-empty name.");
             }
 
             // Use the appropriate orchestrator method based on preferences
@@ -810,7 +826,8 @@ namespace DotCompute.Core.Pipelines
             {
                 if (string.IsNullOrEmpty(parallelStep.KernelName))
                 {
-                    throw new InvalidOperationException("Kernel name is required for parallel steps");
+                    throw new InvalidOperationException(
+                        $"Parallel step {parallelStep.StepId} (index={parallelStep.ExecutionOrder}) has no kernel name. Every tuple passed to Parallel(...) must have a non-empty kernelName referring to a registered [Kernel] method.");
                 }
 
 
@@ -840,7 +857,8 @@ namespace DotCompute.Core.Pipelines
             if (step.BranchCondition == null)
             {
 
-                throw new InvalidOperationException("Branch condition is required for branch steps");
+                throw new InvalidOperationException(
+                    $"Branch step {step.StepId} (order={step.ExecutionOrder}) has no condition. Branch<T>(condition, truePath, falsePath) requires a non-null condition delegate — this typically means the step was constructed manually instead of via Branch<T>(...).");
             }
 
 

--- a/src/Core/DotCompute.Core/Pipelines/KernelPipeline.cs
+++ b/src/Core/DotCompute.Core/Pipelines/KernelPipeline.cs
@@ -117,8 +117,11 @@ namespace DotCompute.Core.Pipelines
                 var validationResult = Validate();
                 if (!validationResult.IsValid)
                 {
+                    var errorSummary = validationResult.Errors is { Count: > 0 } errs
+                        ? string.Join("; ", errs.Select(e => $"[{e.Code}] {e.Message}"))
+                        : "(no error details)";
                     throw new PipelineValidationException(
-                        "Pipeline validation failed",
+                        $"Pipeline '{Name}' (id={Id}) failed validation with {validationResult.Errors?.Count ?? 0} error(s) and {validationResult.Warnings?.Count ?? 0} warning(s): {errorSummary}. Fix the reported issues before calling ExecuteAsync, or review each ValidationIssue in the Issues property for detailed codes.",
                         ConvertValidationIssues(validationResult.Errors ?? []),
                         validationResult.Warnings);
                 }
@@ -273,7 +276,7 @@ namespace DotCompute.Core.Pipelines
                 });
 
                 throw new PipelineExecutionException(
-                    $"Pipeline execution failed: {ex.Message}",
+                    $"Pipeline '{Name}' (id={Id}, executionId={executionId}) failed after running {stageResults.Count}/{_stages.Count} stages: {ex.GetType().Name}: {ex.Message}. See inner exception for the stage-level cause; check Errors collection on this exception for structured diagnostics.",
                     Id,
                     errors,
                     null,

--- a/src/Core/DotCompute.Core/Pipelines/KernelPipelineBuilder.cs
+++ b/src/Core/DotCompute.Core/Pipelines/KernelPipelineBuilder.cs
@@ -51,7 +51,9 @@ namespace DotCompute.Core.Pipelines
         /// <inheritdoc/>
         public IKernelPipelineBuilder WithName(string name)
         {
-            _name = name ?? throw new ArgumentNullException(nameof(name));
+            _name = name ?? throw new ArgumentNullException(
+                nameof(name),
+                "Pipeline name is required by WithName(string). Pass a non-null identifier for diagnostic and logging output.");
             return this;
         }
 
@@ -126,7 +128,9 @@ namespace DotCompute.Core.Pipelines
         /// <inheritdoc/>
         public IKernelPipelineBuilder AddStage(IPipelineStage stage)
         {
-            _stages.Add(stage ?? throw new ArgumentNullException(nameof(stage)));
+            _stages.Add(stage ?? throw new ArgumentNullException(
+                nameof(stage),
+                "Cannot add a null stage to the pipeline. Construct a concrete IPipelineStage (KernelStage, BranchStage, LoopStage, ParallelStage, or custom) and pass it to AddStage."));
             return this;
         }
 
@@ -218,8 +222,12 @@ namespace DotCompute.Core.Pipelines
     /// </summary>
     internal sealed class KernelStageBuilder(string name, ICompiledKernel kernel) : IKernelStageBuilder
     {
-        private readonly string _name = name ?? throw new ArgumentNullException(nameof(name));
-        private readonly ICompiledKernel _kernel = kernel ?? throw new ArgumentNullException(nameof(kernel));
+        private readonly string _name = name ?? throw new ArgumentNullException(
+            nameof(name),
+            "Stage name is required when constructing a KernelStageBuilder. Pass a unique, non-null identifier for the stage (used in metrics, logging, and dependency resolution).");
+        private readonly ICompiledKernel _kernel = kernel ?? throw new ArgumentNullException(
+            nameof(kernel),
+            "A compiled kernel is required for a KernelStageBuilder. Obtain one from IUnifiedKernelCompiler.CompileAsync(...) or IComputeOrchestrator, then pass it to AddKernel(name, kernel, ...).");
         private readonly List<string> _dependencies = [];
         private readonly Dictionary<string, object> _metadata = [];
         private readonly Dictionary<string, string> _inputMappings = [];
@@ -261,7 +269,9 @@ namespace DotCompute.Core.Pipelines
         /// <inheritdoc/>
         public IKernelStageBuilder WithWorkSize(params long[] globalWorkSize)
         {
-            _globalWorkSize = globalWorkSize ?? throw new ArgumentNullException(nameof(globalWorkSize));
+            _globalWorkSize = globalWorkSize ?? throw new ArgumentNullException(
+                nameof(globalWorkSize),
+                "Global work size is required by WithWorkSize(params long[]). Pass a 1-, 2-, or 3-dimensional size array matching the kernel's dimensionality (e.g., WithWorkSize(n) for 1D, WithWorkSize(w, h) for 2D).");
             return this;
         }
 

--- a/src/Core/DotCompute.Core/Pipelines/Optimization/Models/CustomOptimizationPass.cs
+++ b/src/Core/DotCompute.Core/Pipelines/Optimization/Models/CustomOptimizationPass.cs
@@ -12,13 +12,17 @@ namespace DotCompute.Core.Pipelines.Optimization.Models;
 /// </summary>
 internal sealed class CustomOptimizationPass(string name, Func<IKernelPipeline, Task<IKernelPipeline>> optimizationLogic) : IOptimizationPass
 {
-    private readonly Func<IKernelPipeline, Task<IKernelPipeline>> _optimizationLogic = optimizationLogic ?? throw new ArgumentNullException(nameof(optimizationLogic));
+    private readonly Func<IKernelPipeline, Task<IKernelPipeline>> _optimizationLogic = optimizationLogic ?? throw new ArgumentNullException(
+        nameof(optimizationLogic),
+        "CustomOptimizationPass requires a non-null optimization delegate. Supply a Func<IKernelPipeline, Task<IKernelPipeline>> that returns the (possibly modified) pipeline.");
     /// <summary>
     /// Gets or sets the name.
     /// </summary>
     /// <value>The name.</value>
 
-    public string Name { get; } = name ?? throw new ArgumentNullException(nameof(name));
+    public string Name { get; } = name ?? throw new ArgumentNullException(
+        nameof(name),
+        "CustomOptimizationPass requires a non-null name — this identifier is shown in optimization pipelines and logs.");
     /// <summary>
     /// Gets or sets the optimization type.
     /// </summary>

--- a/src/Core/DotCompute.Core/Pipelines/Optimization/Utilities/IntelligentBufferSizeCalculator.cs
+++ b/src/Core/DotCompute.Core/Pipelines/Optimization/Utilities/IntelligentBufferSizeCalculator.cs
@@ -25,14 +25,16 @@ public static class IntelligentBufferSizeCalculator
         if (elementCount <= 0)
         {
 
-            throw new ArgumentOutOfRangeException(nameof(elementCount), "Element count must be positive");
+            throw new ArgumentOutOfRangeException(nameof(elementCount), elementCount,
+                $"Element count must be greater than zero for buffer size calculation (received {elementCount}). Pass the number of elements the pipeline will process.");
         }
 
 
         if (elementSize <= 0)
         {
 
-            throw new ArgumentOutOfRangeException(nameof(elementSize), "Element size must be positive");
+            throw new ArgumentOutOfRangeException(nameof(elementSize), elementSize,
+                $"Element size must be greater than zero (received {elementSize} bytes). Pass sizeof(T) or Unsafe.SizeOf<T>() of the element type.");
         }
 
         // Calculate total data size
@@ -128,7 +130,8 @@ public static class IntelligentBufferSizeCalculator
         if (bufferSize <= 0)
         {
 
-            throw new ArgumentOutOfRangeException(nameof(bufferSize), "Buffer size must be positive");
+            throw new ArgumentOutOfRangeException(nameof(bufferSize), bufferSize,
+                $"Buffer size must be greater than zero for buffer-count calculation (received {bufferSize} bytes). Use CalculateOptimalBufferSize(...) to derive a valid size first.");
         }
 
 

--- a/src/Core/DotCompute.Core/Pipelines/PipelineMemoryManager.cs
+++ b/src/Core/DotCompute.Core/Pipelines/PipelineMemoryManager.cs
@@ -21,7 +21,9 @@ namespace DotCompute.Core.Pipelines
     internal sealed class PipelineMemoryManager(IComputeDevice device) : IPipelineMemoryManager
     {
 #pragma warning disable CA2213 // Disposable fields should be disposed - Injected dependency, not owned by this class
-        private readonly IComputeDevice _device = device ?? throw new ArgumentNullException(nameof(device));
+        private readonly IComputeDevice _device = device ?? throw new ArgumentNullException(
+            nameof(device),
+            "IComputeDevice is required for PipelineMemoryManager — pass a device obtained from IAccelerator.Device or IAcceleratorProvider.");
 #pragma warning restore CA2213
         private readonly ConcurrentDictionary<string, object> _sharedMemories = new();
         private readonly ConcurrentDictionary<Type, MemoryPool> _pools = new();
@@ -71,7 +73,9 @@ namespace DotCompute.Core.Pipelines
             catch (Exception ex)
             {
                 throw new InvalidOperationException(
-                    $"Failed to allocate {sizeInBytes} bytes for {elementCount} elements of type {typeof(T).Name}", ex);
+                    $"Pipeline memory allocation failed: device '{_device.Name}' could not allocate {sizeInBytes:N0} bytes ({elementCount:N0} x {typeof(T).Name}, access={memoryAccess}). " +
+                    $"Current usage: {_currentUsedBytes:N0}/{_totalAllocatedBytes:N0} bytes, {_activeAllocationCount} active allocations. " +
+                    $"Likely causes: out-of-memory, fragmented pool, or oversized request. See inner exception for device-specific detail.", ex);
             }
 
             // Update statistics atomically
@@ -99,16 +103,16 @@ namespace DotCompute.Core.Pipelines
                     if (existingTyped.ElementCount != elementCount)
                     {
                         throw new InvalidOperationException(
-                            $"Shared memory '{key}' exists but has different element count. " +
-                            $"Expected: {elementCount}, Actual: {existingTyped.ElementCount}");
+                            $"Shared memory key '{key}' was previously allocated with {existingTyped.ElementCount:N0} elements of {typeof(T).Name}, but AllocateSharedAsync requested {elementCount:N0}. " +
+                            $"Either use the same element count on every call for this key, use a different key for differently-sized buffers, or release the existing allocation before requesting a new size.");
                     }
                     return existingTyped;
                 }
                 else
                 {
                     throw new InvalidOperationException(
-                        $"Shared memory '{key}' exists but has incompatible type. " +
-                        $"Expected: {typeof(IPipelineMemory<T>).Name}, Actual: {existing.GetType().Name}");
+                        $"Shared memory key '{key}' is already registered as {existing.GetType().Name}, but AllocateSharedAsync<{typeof(T).Name}> expects {typeof(IPipelineMemory<T>).Name}. " +
+                        $"Shared-memory keys are unique per type — choose a distinct key for each element type, or release the existing allocation before rebinding the key.");
                 }
             }
 
@@ -121,7 +125,7 @@ namespace DotCompute.Core.Pipelines
             catch (Exception ex)
             {
                 throw new InvalidOperationException(
-                    $"Failed to allocate shared memory '{key}' for {elementCount} elements of type {typeof(T).Name}", ex);
+                    $"Shared memory allocation for key '{key}' failed: could not allocate {elementCount:N0} elements of {typeof(T).Name} on device '{_device.Name}'. See inner exception for the underlying allocation failure.", ex);
             }
 
             // Atomic add operation with conflict detection
@@ -134,7 +138,8 @@ namespace DotCompute.Core.Pipelines
                 {
                     return concurrentTyped;
                 }
-                throw new InvalidOperationException($"Concurrent allocation conflict for shared memory key '{key}'");
+                throw new InvalidOperationException(
+                    $"Concurrent allocation conflict for shared memory key '{key}': another thread registered a non-{typeof(T).Name} allocation under this key between our TryAdd attempt and the fallback lookup. Retry AllocateSharedAsync or serialize shared-memory creation for this key.");
             }
 
             return memory;
@@ -292,14 +297,15 @@ namespace DotCompute.Core.Pipelines
         {
             if (elementCount <= 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(elementCount), elementCount, "Element count must be positive");
+                throw new ArgumentOutOfRangeException(nameof(elementCount), elementCount,
+                    $"Element count must be greater than zero (received {elementCount} for type {typeof(T).Name}). For zero-length buffers use a sentinel or skip the allocation entirely.");
             }
 
             var elementSize = global::System.Runtime.CompilerServices.Unsafe.SizeOf<T>();
             if (elementCount > long.MaxValue / elementSize)
             {
                 throw new ArgumentOutOfRangeException(nameof(elementCount), elementCount,
-                    $"Element count would cause overflow for type {typeof(T).Name} with size {elementSize} bytes");
+                    $"Allocation would overflow Int64: {elementCount:N0} elements x {elementSize} bytes/element for type {typeof(T).Name} exceeds long.MaxValue ({long.MaxValue:N0}). Reduce element count or split into multiple buffers.");
             }
         }
 
@@ -478,7 +484,7 @@ namespace DotCompute.Core.Pipelines
             catch (Exception ex)
             {
                 throw new InvalidOperationException(
-                    $"Failed to copy {source.Length} elements to device memory at offset {offset}", ex);
+                    $"Host-to-device copy failed: could not write {source.Length:N0} elements of {typeof(T).Name} to device memory at element offset {offset} (byte offset {byteOffset}). Buffer element count: {_elementCount:N0}. See inner exception for transport-level detail.", ex);
             }
         }
 
@@ -503,7 +509,7 @@ namespace DotCompute.Core.Pipelines
             catch (Exception ex)
             {
                 throw new InvalidOperationException(
-                    $"Failed to copy {actualCount} elements from device memory at offset {offset}", ex);
+                    $"Device-to-host copy failed: could not read {actualCount:N0} elements of {typeof(T).Name} from device memory at element offset {offset} (byte offset {byteOffset}). Buffer element count: {_elementCount:N0}, destination capacity: {destination.Length:N0}. See inner exception for transport-level detail.", ex);
             }
         }
 
@@ -514,7 +520,8 @@ namespace DotCompute.Core.Pipelines
 
             if (offset + length > _elementCount)
             {
-                throw new ArgumentOutOfRangeException(nameof(length), "Slice exceeds memory bounds");
+                throw new ArgumentOutOfRangeException(nameof(length),
+                    $"Slice range [{offset}, {offset + length}) exceeds buffer length {_elementCount}. Slice(offset, length) must satisfy offset + length <= buffer.ElementCount.");
             }
 
             return new PipelineMemoryView<T>(this, offset, length);
@@ -582,14 +589,14 @@ namespace DotCompute.Core.Pipelines
             if (mode == MemoryLockMode.ReadOnly && AccessMode == MemoryAccess.WriteOnly)
             {
                 throw new InvalidOperationException(
-                    "Cannot acquire read lock on write-only memory");
+                    $"Cannot acquire a {mode} lock: this pipeline memory was allocated with AccessMode=WriteOnly. Allocate with ReadOnly or ReadWrite access if you need to read from it.");
             }
 
             if ((mode == MemoryLockMode.ReadWrite || mode == MemoryLockMode.Exclusive) &&
                 AccessMode == MemoryAccess.ReadOnly)
             {
                 throw new InvalidOperationException(
-                    "Cannot acquire write lock on read-only memory");
+                    $"Cannot acquire a {mode} lock: this pipeline memory was allocated with AccessMode=ReadOnly. Allocate with WriteOnly or ReadWrite access if you need to write to it.");
             }
         }
 
@@ -597,18 +604,20 @@ namespace DotCompute.Core.Pipelines
         {
             if (offset < 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(offset), offset, "Offset cannot be negative");
+                throw new ArgumentOutOfRangeException(nameof(offset), offset,
+                    $"CopyFromAsync offset must be non-negative (got {offset}). Offset is in elements of {typeof(T).Name}.");
             }
 
             if (offset + source.Length > _elementCount)
             {
                 throw new ArgumentOutOfRangeException(nameof(source),
-                    $"Source data ({source.Length} elements) with offset {offset} exceeds memory bounds ({_elementCount} elements)");
+                    $"Source copy range [{offset}, {offset + source.Length}) exceeds buffer length {_elementCount}. Reduce source length to at most {_elementCount - offset} elements, or increase buffer capacity at allocation time.");
             }
 
             if (AccessMode == MemoryAccess.ReadOnly)
             {
-                throw new InvalidOperationException("Cannot write to read-only memory");
+                throw new InvalidOperationException(
+                    "Cannot write to this pipeline memory: AccessMode=ReadOnly. Allocate with MemoryAccess.WriteOnly or MemoryAccess.ReadWrite (via MemoryHint.WriteHeavy or ReadWrite) to perform host-to-device copies.");
             }
         }
 
@@ -616,23 +625,26 @@ namespace DotCompute.Core.Pipelines
         {
             if (offset < 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(offset), offset, "Offset cannot be negative");
+                throw new ArgumentOutOfRangeException(nameof(offset), offset,
+                    $"CopyToAsync offset must be non-negative (got {offset}). Offset is in elements of {typeof(T).Name}.");
             }
 
             if (offset >= _elementCount)
             {
                 throw new ArgumentOutOfRangeException(nameof(offset), offset,
-                    $"Offset exceeds memory bounds ({_elementCount} elements)");
+                    $"CopyToAsync offset {offset} is past the end of the buffer ({_elementCount} elements of {typeof(T).Name}). Valid offsets are in the range [0, {_elementCount - 1}].");
             }
 
             if (count.HasValue && count.Value < 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(count), count.Value, "Count cannot be negative");
+                throw new ArgumentOutOfRangeException(nameof(count), count.Value,
+                    $"CopyToAsync count must be non-negative when specified (got {count.Value}). Pass null to copy as many elements as fit in destination.");
             }
 
             if (AccessMode == MemoryAccess.WriteOnly)
             {
-                throw new InvalidOperationException("Cannot read from write-only memory");
+                throw new InvalidOperationException(
+                    "Cannot read from this pipeline memory: AccessMode=WriteOnly. Allocate with MemoryAccess.ReadOnly or MemoryAccess.ReadWrite (via MemoryHint.ReadHeavy or ReadWrite) to perform device-to-host copies.");
             }
         }
 
@@ -657,7 +669,8 @@ namespace DotCompute.Core.Pipelines
         {
             if (offset < 0 || length <= 0 || offset + length > parent.ElementCount)
             {
-                throw new ArgumentOutOfRangeException(nameof(offset), "Invalid view bounds");
+                throw new ArgumentOutOfRangeException(nameof(offset),
+                    $"PipelineMemoryView bounds [{offset}, {offset + length}) are invalid for a parent buffer of {parent.ElementCount} elements. Requires: offset >= 0, length > 0, offset + length <= parent.ElementCount.");
             }
 
             Parent = parent;
@@ -679,7 +692,8 @@ namespace DotCompute.Core.Pipelines
         {
             if (offset < 0 || length <= 0 || offset + length > Length)
             {
-                throw new ArgumentOutOfRangeException(nameof(offset), "Invalid sub-view bounds");
+                throw new ArgumentOutOfRangeException(nameof(offset),
+                    $"Sub-slice bounds [{offset}, {offset + length}) are invalid for a view of length {Length}. Requires: offset >= 0, length > 0, offset + length <= view.Length.");
             }
 
             return new PipelineMemoryView<T>(Parent, Offset + offset, length);

--- a/src/Core/DotCompute.Core/Pipelines/PipelineMetrics.cs
+++ b/src/Core/DotCompute.Core/Pipelines/PipelineMetrics.cs
@@ -285,7 +285,9 @@ namespace DotCompute.Core.Pipelines
                 MetricsExportFormat.Csv => ExportCsv(),
                 MetricsExportFormat.Prometheus => ExportPrometheus(),
                 MetricsExportFormat.OpenTelemetry => ExportOpenTelemetry(),
-                _ => throw new ArgumentException($"Unsupported export format: {format}")
+                _ => throw new ArgumentException(
+                    $"Unsupported MetricsExportFormat value '{format}' ({(int)format}). Supported formats: Json, Csv, Prometheus, OpenTelemetry. Add a new ExportXxx method and handler case if a new format is required.",
+                    nameof(format))
             };
         }
 

--- a/src/Core/DotCompute.Core/Pipelines/PipelineOptimizer.cs
+++ b/src/Core/DotCompute.Core/Pipelines/PipelineOptimizer.cs
@@ -543,7 +543,9 @@ namespace DotCompute.Core.Pipelines
 
             if (string.IsNullOrEmpty(strategyName))
             {
-                throw new ArgumentException("Strategy name cannot be empty.", nameof(strategyName));
+                throw new ArgumentException(
+                    $"Optimization strategy name must be a non-empty string (got empty string). Pass a unique identifier so GetOptimizationStrategy(name) can retrieve it later.",
+                    nameof(strategyName));
             }
 
             _namedStrategies[strategyName] = strategy;

--- a/src/Core/DotCompute.Core/Pipelines/Services/Implementation/DefaultKernelResolver.cs
+++ b/src/Core/DotCompute.Core/Pipelines/Services/Implementation/DefaultKernelResolver.cs
@@ -108,7 +108,9 @@ namespace DotCompute.Core.Pipelines.Services.Implementation
         {
             if (string.IsNullOrWhiteSpace(kernelName))
             {
-                throw new ArgumentException("Kernel name cannot be null or whitespace", nameof(kernelName));
+                throw new ArgumentException(
+                    $"Kernel name must be a non-empty, non-whitespace string; received '{kernelName ?? "<null>"}'. Pass the identifier used by [Kernel] registration or IKernelResolver.RegisterKernel.",
+                    nameof(kernelName));
             }
 
             // Check cache first

--- a/src/Core/DotCompute.Core/Pipelines/Stages/CustomSyncStrategy.cs
+++ b/src/Core/DotCompute.Core/Pipelines/Stages/CustomSyncStrategy.cs
@@ -50,7 +50,8 @@ public abstract class CustomSyncStrategy : IAsyncDisposable
         if (!SupportsTimeout)
         {
 
-            throw new NotSupportedException($"Synchronization strategy '{Name}' does not support timeout operations.");
+            throw new NotSupportedException(
+                $"Synchronization strategy '{Name}' does not implement timeout-based SynchronizeAsync (SupportsTimeout=false). Use SynchronizeAsync(participantId, cancellationToken) with a linked CancellationTokenSource for time-bounded waits, or switch to a strategy that returns SupportsTimeout=true.");
         }
 
 
@@ -63,7 +64,8 @@ public abstract class CustomSyncStrategy : IAsyncDisposable
         }
         catch (OperationCanceledException) when (timeoutCts.Token.IsCancellationRequested)
         {
-            throw new TimeoutException($"Synchronization for participant {participantId} timed out after {timeout}.");
+            throw new TimeoutException(
+                $"Synchronization for participant {participantId} using strategy '{Name}' timed out after {timeout} ({timeout.TotalMilliseconds:F0} ms). Other participants may not have reached the sync point; increase the timeout, check for deadlocks, or verify all participants signal before the deadline.");
         }
     }
 
@@ -118,7 +120,8 @@ public sealed class BarrierSyncStrategy : CustomSyncStrategy
         if (_barrier == null)
         {
 
-            throw new InvalidOperationException("Strategy must be initialized before use.");
+            throw new InvalidOperationException(
+                $"BarrierSyncStrategy has not been initialized. Call InitializeAsync(participantCount, cancellationToken) before SynchronizeAsync — each strategy instance requires a participant count before the underlying Barrier can be constructed.");
         }
 
 
@@ -167,7 +170,8 @@ public sealed class CountdownSyncStrategy(int requiredCount = 0) : CustomSyncStr
         if (_countdown == null)
         {
 
-            throw new InvalidOperationException("Strategy must be initialized before use.");
+            throw new InvalidOperationException(
+                $"CountdownSyncStrategy({_requiredCount}) has not been initialized. Call InitializeAsync(participantCount, cancellationToken) before SynchronizeAsync — the CountdownEvent is lazily created from the participant count.");
         }
 
 

--- a/src/Core/DotCompute.Core/Pipelines/Stages/DeferredKernelStage.cs
+++ b/src/Core/DotCompute.Core/Pipelines/Stages/DeferredKernelStage.cs
@@ -35,7 +35,9 @@ internal sealed class DeferredKernelStage : IPipelineStage
     /// <param name="stageBuilderAction">Optional configuration action for the stage.</param>
     public DeferredKernelStage(string kernelName, Action<IKernelStageBuilder>? stageBuilderAction)
     {
-        _kernelName = kernelName ?? throw new ArgumentNullException(nameof(kernelName));
+        _kernelName = kernelName ?? throw new ArgumentNullException(
+            nameof(kernelName),
+            "Kernel name is required for DeferredKernelStage — pass the name used to register the kernel (via [Kernel] attribute or IKernelResolver). The stage resolves and compiles the kernel lazily at first execution.");
         _stageBuilderAction = stageBuilderAction;
         Id = $"DeferredKernel_{kernelName}_{Guid.NewGuid():N}";
         _metrics = new StageMetrics(Id);

--- a/src/Core/DotCompute.Core/Pipelines/Stages/KernelStage.cs
+++ b/src/Core/DotCompute.Core/Pipelines/Stages/KernelStage.cs
@@ -67,7 +67,9 @@ namespace DotCompute.Core.Pipelines.Stages
                 }
                 else
                 {
-                    throw new InvalidOperationException($"No value found for parameter '{paramName}' (mapped from '{contextKey}')");
+                    throw new InvalidOperationException(
+                        $"Parameter '{paramName}' for kernel stage '{Name}' could not be resolved: the mapped context key '{contextKey}' is not present in PipelineExecutionContext.Inputs and no default was configured via SetParameter. " +
+                        $"Ensure the upstream stage publishes '{contextKey}' (via MapOutput), or set a default with SetParameter(\"{paramName}\", value).");
                 }
             }
 

--- a/src/Core/DotCompute.Core/Recovery/CircuitBreaker.cs
+++ b/src/Core/DotCompute.Core/Recovery/CircuitBreaker.cs
@@ -45,7 +45,9 @@ public sealed partial class CircuitBreaker : IDisposable
 
     public CircuitBreaker(ILogger<CircuitBreaker> logger, CircuitBreakerConfiguration? config = null)
     {
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _logger = logger ?? throw new ArgumentNullException(
+            nameof(logger),
+            "ILogger<CircuitBreaker> is required — the breaker emits trip/reset events and health-check diagnostics through this logger. Register logging via AddLogging() or AddDotComputeRuntime().");
         _config = config ?? CircuitBreakerConfiguration.Default;
         _serviceStates = new ConcurrentDictionary<string, ServiceCircuitState>();
 

--- a/src/Core/DotCompute.Core/Recovery/Compilation/CompilationHistory.cs
+++ b/src/Core/DotCompute.Core/Recovery/Compilation/CompilationHistory.cs
@@ -30,7 +30,9 @@ namespace DotCompute.Core.Recovery.Compilation;
 /// <exception cref="ArgumentNullException">Thrown when <paramref name="kernelName"/> is null.</exception>
 public sealed class CompilationHistory(string kernelName) : IDisposable
 {
-    private readonly string _kernelName = kernelName ?? throw new ArgumentNullException(nameof(kernelName));
+    private readonly string _kernelName = kernelName ?? throw new ArgumentNullException(
+        nameof(kernelName),
+        "CompilationHistory requires a non-null kernel name — used to correlate fallback attempts and error history with a specific kernel.");
     private readonly List<Exception> _recentErrors = [];
     private readonly List<CompilationFallbackStrategy> _attemptedStrategies = [];
     private int _failureCount;

--- a/src/Core/DotCompute.Core/Recovery/DeviceRecoveryState.cs
+++ b/src/Core/DotCompute.Core/Recovery/DeviceRecoveryState.cs
@@ -21,7 +21,9 @@ public class DeviceRecoveryState(string deviceId)
     /// </summary>
     /// <value>The device id.</value>
 
-    public string DeviceId { get; } = deviceId ?? throw new ArgumentNullException(nameof(deviceId));
+    public string DeviceId { get; } = deviceId ?? throw new ArgumentNullException(
+        nameof(deviceId),
+        "DeviceRecoveryState requires a non-null device identifier — this key (typically IAccelerator.Info.Id) links recovery history to the specific hardware device.");
     /// <summary>
     /// Gets or sets a value indicating whether healthy.
     /// </summary>

--- a/src/Core/DotCompute.Core/Recovery/Gpu/DeviceRecoveryState.cs
+++ b/src/Core/DotCompute.Core/Recovery/Gpu/DeviceRecoveryState.cs
@@ -32,7 +32,9 @@ public class DeviceRecoveryState(string deviceId)
     /// Gets the unique identifier of the GPU device this state tracks.
     /// </summary>
     /// <value>The device identifier string.</value>
-    public string DeviceId { get; } = deviceId ?? throw new ArgumentNullException(nameof(deviceId));
+    public string DeviceId { get; } = deviceId ?? throw new ArgumentNullException(
+        nameof(deviceId),
+        "GPU DeviceRecoveryState requires a non-null device identifier — this key (typically IAccelerator.Info.Id) tracks recovery history per GPU.");
 
     /// <summary>
     /// Gets a value indicating whether the device is currently considered healthy.

--- a/src/Core/DotCompute.Core/Recovery/Gpu/KernelExecutionMonitor.cs
+++ b/src/Core/DotCompute.Core/Recovery/Gpu/KernelExecutionMonitor.cs
@@ -25,7 +25,9 @@ namespace DotCompute.Core.Recovery.Gpu;
 /// <exception cref="ArgumentNullException">Thrown when <paramref name="kernelId"/> or <paramref name="logger"/> is null.</exception>
 public sealed class KernelExecutionMonitor(string kernelId, TimeSpan timeout, ILogger logger, string deviceId = "unknown") : IKernelExecutionMonitor
 {
-    private readonly ILogger _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    private readonly ILogger _logger = logger ?? throw new ArgumentNullException(
+        nameof(logger),
+        $"ILogger is required for GPU KernelExecutionMonitor('{kernelId}' on '{deviceId}'). Pass a non-null logger from ILoggerFactory for hang-detection diagnostics.");
     private readonly CancellationTokenSource _cancellationTokenSource = new();
     private readonly DateTimeOffset _startTime = DateTimeOffset.UtcNow;
     private readonly TimeSpan _timeout = timeout;
@@ -36,7 +38,9 @@ public sealed class KernelExecutionMonitor(string kernelId, TimeSpan timeout, IL
     /// Gets the unique identifier of the kernel being monitored.
     /// </summary>
     /// <value>The kernel identifier string.</value>
-    public string KernelId { get; } = kernelId ?? throw new ArgumentNullException(nameof(kernelId));
+    public string KernelId { get; } = kernelId ?? throw new ArgumentNullException(
+        nameof(kernelId),
+        "GPU KernelExecutionMonitor requires a non-null kernel identifier — used to correlate monitor events with the specific kernel instance.");
 
     /// <summary>
     /// Gets the identifier of the GPU device where the kernel is executing.

--- a/src/Core/DotCompute.Core/Recovery/GpuRecoveryManager.cs
+++ b/src/Core/DotCompute.Core/Recovery/GpuRecoveryManager.cs
@@ -213,7 +213,9 @@ public sealed partial class GpuRecoveryManager : IDisposable
 
     public GpuRecoveryManager(ILogger<GpuRecoveryManager> logger, GpuRecoveryConfiguration? config = null)
     {
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _logger = logger ?? throw new ArgumentNullException(
+            nameof(logger),
+            "ILogger<GpuRecoveryManager> is required — the manager emits device-recovery transitions and kernel-hang detections through this logger. Register logging via AddLogging() in startup.");
         _config = config ?? GpuRecoveryConfiguration.Default;
         _deviceStates = new ConcurrentDictionary<string, DeviceRecoveryState>();
         _kernelMonitors = new ConcurrentDictionary<string, KernelExecutionMonitor>();

--- a/src/Core/DotCompute.Core/Recovery/KernelExecutionMonitor.cs
+++ b/src/Core/DotCompute.Core/Recovery/KernelExecutionMonitor.cs
@@ -12,7 +12,9 @@ namespace DotCompute.Core.Recovery;
 /// </summary>
 public sealed class KernelExecutionMonitor(string kernelId, TimeSpan timeout, ILogger logger, string deviceId = "unknown") : IKernelExecutionMonitor
 {
-    private readonly ILogger _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    private readonly ILogger _logger = logger ?? throw new ArgumentNullException(
+        nameof(logger),
+        $"ILogger is required for KernelExecutionMonitor('{kernelId}' on '{deviceId}'). Pass a non-null logger from ILoggerFactory to emit timeout/hang diagnostics.");
     private readonly CancellationTokenSource _cancellationTokenSource = new();
     private readonly DateTimeOffset _startTime = DateTimeOffset.UtcNow;
     private readonly TimeSpan _timeout = timeout;
@@ -23,7 +25,9 @@ public sealed class KernelExecutionMonitor(string kernelId, TimeSpan timeout, IL
     /// </summary>
     /// <value>The kernel id.</value>
 
-    public string KernelId { get; } = kernelId ?? throw new ArgumentNullException(nameof(kernelId));
+    public string KernelId { get; } = kernelId ?? throw new ArgumentNullException(
+        nameof(kernelId),
+        "KernelExecutionMonitor requires a non-null kernel identifier — used to correlate monitor events with the kernel execution stream.");
     /// <summary>
     /// Gets or sets the device identifier.
     /// </summary>

--- a/src/Core/DotCompute.Core/Recovery/MemoryRecoveryStrategy.cs
+++ b/src/Core/DotCompute.Core/Recovery/MemoryRecoveryStrategy.cs
@@ -171,7 +171,9 @@ public sealed partial class MemoryRecoveryStrategy : BaseRecoveryStrategy<Models
         catch (OutOfMemoryException ex)
         {
             LogMemoryAllocationFailedAfterRetries(Logger, maxRetries);
-            throw new MemoryAllocationException($"Failed to allocate memory after {maxRetries} attempts", ex);
+            throw new MemoryAllocationException(
+                $"Memory allocation failed after {maxRetries} retry attempts with exponential backoff. All recovery strategies (GC, defragmentation, retry) exhausted. See inner OutOfMemoryException. To diagnose: enable GC server mode, increase process memory, pre-allocate pools, or reduce peak working set.",
+                ex);
         }
     }
 

--- a/src/Core/DotCompute.Core/Recovery/Models/MemoryPressureMonitor.cs
+++ b/src/Core/DotCompute.Core/Recovery/Models/MemoryPressureMonitor.cs
@@ -27,7 +27,9 @@ public sealed class MemoryPressureMonitor : IDisposable
     /// <param name="updateInterval">The interval between pressure updates. Defaults to 5 seconds.</param>
     public MemoryPressureMonitor(ILogger<MemoryPressureMonitor> logger, TimeSpan? updateInterval = null)
     {
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _logger = logger ?? throw new ArgumentNullException(
+            nameof(logger),
+            "ILogger<MemoryPressureMonitor> is required — the monitor emits pressure-threshold crossings through this logger. Register logging via AddLogging() in startup.");
         var interval = updateInterval ?? TimeSpan.FromSeconds(5);
 
 

--- a/src/Core/DotCompute.Core/Recovery/PluginRecoveryConfiguration.cs
+++ b/src/Core/DotCompute.Core/Recovery/PluginRecoveryConfiguration.cs
@@ -107,63 +107,81 @@ public class PluginRecoveryConfiguration
         if (RecoveryTimeout <= TimeSpan.Zero)
         {
 
-            throw new ArgumentException("Recovery timeout must be positive", nameof(RecoveryTimeout));
+            throw new ArgumentException(
+                $"PluginRecoveryConfiguration.RecoveryTimeout must be a positive duration (received {RecoveryTimeout}). Set a non-zero deadline before each recovery attempt times out, e.g., TimeSpan.FromSeconds(30).",
+                nameof(RecoveryTimeout));
         }
 
 
         if (MaxRecoveryAttempts <= 0)
         {
 
-            throw new ArgumentException("Max recovery attempts must be positive", nameof(MaxRecoveryAttempts));
+            throw new ArgumentException(
+                $"PluginRecoveryConfiguration.MaxRecoveryAttempts must be >= 1 (received {MaxRecoveryAttempts}). To disable recovery, set EnableAutoRecovery=false; MaxRecoveryAttempts=0 would skip recovery without signalling that intent.",
+                nameof(MaxRecoveryAttempts));
         }
 
 
         if (RecoveryInterval <= TimeSpan.Zero)
         {
 
-            throw new ArgumentException("Recovery interval must be positive", nameof(RecoveryInterval));
+            throw new ArgumentException(
+                $"PluginRecoveryConfiguration.RecoveryInterval must be a positive duration (received {RecoveryInterval}). This is the backoff between recovery attempts — set at least TimeSpan.FromMilliseconds(100).",
+                nameof(RecoveryInterval));
         }
 
 
         if (HealthCheckInterval <= TimeSpan.Zero)
         {
 
-            throw new ArgumentException("Health check interval must be positive", nameof(HealthCheckInterval));
+            throw new ArgumentException(
+                $"PluginRecoveryConfiguration.HealthCheckInterval must be a positive duration (received {HealthCheckInterval}). This controls how often the recovery manager polls plugin health — set at least TimeSpan.FromSeconds(1).",
+                nameof(HealthCheckInterval));
         }
 
 
         if (MaxMemoryUsageBytes <= 0)
         {
 
-            throw new ArgumentException("Max memory usage must be positive", nameof(MaxMemoryUsageBytes));
+            throw new ArgumentException(
+                $"PluginRecoveryConfiguration.MaxMemoryUsageBytes must be greater than zero (received {MaxMemoryUsageBytes:N0} bytes). Set the threshold at which the recovery manager considers the plugin memory-pressured, e.g., 1024L * 1024 * 1024 for 1 GiB.",
+                nameof(MaxMemoryUsageBytes));
         }
 
 
         if (MaxCpuUsagePercent is <= 0 or > 100)
         {
 
-            throw new ArgumentException("Max CPU usage must be between 0 and 100", nameof(MaxCpuUsagePercent));
+            throw new ArgumentException(
+                $"PluginRecoveryConfiguration.MaxCpuUsagePercent must be in (0, 100] (received {MaxCpuUsagePercent:F2}%). Set the CPU-pressure threshold at which the recovery manager should consider intervention — typical values: 70-90%.",
+                nameof(MaxCpuUsagePercent));
         }
 
 
         if (RestartDelay <= TimeSpan.Zero)
         {
 
-            throw new ArgumentException("Restart delay must be positive", nameof(RestartDelay));
+            throw new ArgumentException(
+                $"PluginRecoveryConfiguration.RestartDelay must be a positive duration (received {RestartDelay}). This is the grace period between plugin stop and restart — set at least TimeSpan.FromMilliseconds(500) to let resources release.",
+                nameof(RestartDelay));
         }
 
 
         if (MaxConsecutiveFailures <= 0)
         {
 
-            throw new ArgumentException("Max consecutive failures must be positive", nameof(MaxConsecutiveFailures));
+            throw new ArgumentException(
+                $"PluginRecoveryConfiguration.MaxConsecutiveFailures must be >= 1 (received {MaxConsecutiveFailures}). This is the streak length that trips the plugin into an unhealthy state — typical values: 3-5.",
+                nameof(MaxConsecutiveFailures));
         }
 
 
         if (MaxRestarts <= 0)
         {
 
-            throw new ArgumentException("Max restarts must be positive", nameof(MaxRestarts));
+            throw new ArgumentException(
+                $"PluginRecoveryConfiguration.MaxRestarts must be >= 1 (received {MaxRestarts}). This caps the total number of times a single plugin instance can be restarted before giving up; set at least 1, or disable auto-restart in PluginRecoveryOptions.",
+                nameof(MaxRestarts));
         }
     }
     /// <summary>

--- a/src/Core/DotCompute.Core/Recovery/PluginRecoveryManager.cs
+++ b/src/Core/DotCompute.Core/Recovery/PluginRecoveryManager.cs
@@ -14,7 +14,9 @@ public sealed class PluginRecoveryManager(
     ILogger<PluginRecoveryManager> logger,
     PluginRecoveryConfiguration? config = null) : IDisposable
 {
-    private readonly ILogger<PluginRecoveryManager> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    private readonly ILogger<PluginRecoveryManager> _logger = logger ?? throw new ArgumentNullException(
+        nameof(logger),
+        "ILogger<PluginRecoveryManager> is required — the manager emits plugin health and restart diagnostics through this logger. Register logging via AddLogging() in startup.");
 #pragma warning disable CA1823 // Avoid unused private fields - Configuration reserved for future recovery strategy implementation
     private readonly PluginRecoveryConfiguration? _config = config;
 #pragma warning restore CA1823

--- a/src/Core/DotCompute.Core/Recovery/ServiceCircuitState.cs
+++ b/src/Core/DotCompute.Core/Recovery/ServiceCircuitState.cs
@@ -28,7 +28,9 @@ public partial class ServiceCircuitState(string serviceName, CircuitBreakerConfi
     /// <summary>
     /// Service identifier
     /// </summary>
-    public string ServiceName { get; set; } = serviceName ?? throw new ArgumentNullException(nameof(serviceName));
+    public string ServiceName { get; set; } = serviceName ?? throw new ArgumentNullException(
+        nameof(serviceName),
+        "ServiceCircuitState requires a non-null service identifier — this name appears in circuit-breaker metrics and telemetry.");
 
     /// <summary>
     /// Current circuit state
@@ -120,8 +122,12 @@ public partial class ServiceCircuitState(string serviceName, CircuitBreakerConfi
     /// </summary>
     public Dictionary<string, object> Metrics { get; init; } = [];
 
-    private readonly CircuitBreakerConfiguration _config = config ?? throw new ArgumentNullException(nameof(config));
-    private readonly ILogger _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    private readonly CircuitBreakerConfiguration _config = config ?? throw new ArgumentNullException(
+        nameof(config),
+        "ServiceCircuitState requires a CircuitBreakerConfiguration — it supplies thresholds for open/half-open transitions. Use CircuitBreakerConfiguration.Default or construct a custom configuration.");
+    private readonly ILogger _logger = logger ?? throw new ArgumentNullException(
+        nameof(logger),
+        "ILogger is required for ServiceCircuitState transition-logging. Pass a non-null logger from ILoggerFactory.");
 
     /// <summary>
     /// Records a successful operation

--- a/src/Extensions/DotCompute.Algorithms/LinearAlgebra/Matrix.cs
+++ b/src/Extensions/DotCompute.Algorithms/LinearAlgebra/Matrix.cs
@@ -47,7 +47,9 @@ public sealed class Matrix : IEquatable<Matrix>
 
         if (data.Length != rows * cols)
         {
-            throw new ArgumentException($"Data array length ({data.Length}) does not match matrix dimensions ({rows}x{cols}).");
+            throw new ArgumentException(
+                $"Matrix data array length {data.Length} does not match the declared dimensions {rows}×{cols} (expected {rows * cols} elements). Pad or reshape the data, or adjust the rows/cols parameters to match the actual data size.",
+                nameof(data));
         }
 
         _rows = rows;
@@ -94,11 +96,13 @@ public sealed class Matrix : IEquatable<Matrix>
         {
             if (row < 0 || row >= _rows)
             {
-                throw new ArgumentOutOfRangeException(nameof(row));
+                throw new ArgumentOutOfRangeException(nameof(row), row,
+                    $"Matrix row index {row} is out of range [0, {_rows}) for this {_rows}×{_cols} matrix.");
             }
             if (col < 0 || col >= _cols)
             {
-                throw new ArgumentOutOfRangeException(nameof(col));
+                throw new ArgumentOutOfRangeException(nameof(col), col,
+                    $"Matrix column index {col} is out of range [0, {_cols}) for this {_rows}×{_cols} matrix.");
             }
             return _data[row * _cols + col];
         }
@@ -107,11 +111,13 @@ public sealed class Matrix : IEquatable<Matrix>
         {
             if (row < 0 || row >= _rows)
             {
-                throw new ArgumentOutOfRangeException(nameof(row));
+                throw new ArgumentOutOfRangeException(nameof(row), row,
+                    $"Matrix row index {row} is out of range [0, {_rows}) for this {_rows}×{_cols} matrix.");
             }
             if (col < 0 || col >= _cols)
             {
-                throw new ArgumentOutOfRangeException(nameof(col));
+                throw new ArgumentOutOfRangeException(nameof(col), col,
+                    $"Matrix column index {col} is out of range [0, {_cols}) for this {_rows}×{_cols} matrix.");
             }
             _data[row * _cols + col] = value;
         }
@@ -207,7 +213,9 @@ public sealed class Matrix : IEquatable<Matrix>
 
         if (min >= max)
         {
-            throw new ArgumentException($"Minimum value ({min}) must be less than maximum value ({max}).");
+            throw new ArgumentException(
+                $"Matrix.Random: min ({min}) must be strictly less than max ({max}) to produce a non-degenerate random range. Swap the arguments, or use Zero() if you want a zero-filled matrix.",
+                nameof(min));
         }
 
         var random = System.Random.Shared;
@@ -255,7 +263,8 @@ public sealed class Matrix : IEquatable<Matrix>
     {
         if (row < 0 || row >= _rows)
         {
-            throw new ArgumentOutOfRangeException(nameof(row));
+            throw new ArgumentOutOfRangeException(nameof(row), row,
+                $"GetRow({row}) is out of range for this {_rows}×{_cols} matrix. Valid rows: [0, {_rows}).");
         }
 
         var result = new Matrix(1, _cols);
@@ -272,7 +281,8 @@ public sealed class Matrix : IEquatable<Matrix>
     {
         if (col < 0 || col >= _cols)
         {
-            throw new ArgumentOutOfRangeException(nameof(col));
+            throw new ArgumentOutOfRangeException(nameof(col), col,
+                $"GetColumn({col}) is out of range for this {_rows}×{_cols} matrix. Valid columns: [0, {_cols}).");
         }
 
         var result = new Matrix(_rows, 1);

--- a/src/Extensions/DotCompute.Algorithms/LinearAlgebra/Operations/MatrixDecomposition.cs
+++ b/src/Extensions/DotCompute.Algorithms/LinearAlgebra/Operations/MatrixDecomposition.cs
@@ -117,7 +117,9 @@ namespace DotCompute.Algorithms.LinearAlgebra.Operations
 
             if (!matrix.IsSquare)
             {
-                throw new ArgumentException("Matrix must be square for LU decomposition.");
+                throw new ArgumentException(
+                    $"LU decomposition requires a square matrix (got {matrix.Rows}×{matrix.Columns}). For rectangular matrices, use QR or SVD decomposition.",
+                    nameof(matrix));
             }
 
             var n = matrix.Rows;
@@ -171,7 +173,8 @@ namespace DotCompute.Algorithms.LinearAlgebra.Operations
                     // Check for singularity
                     if (Math.Abs(u[k, k]) < 1e-10f)
                     {
-                        throw new InvalidOperationException("Matrix is singular or nearly singular.");
+                        throw new InvalidOperationException(
+                            $"LU decomposition failed at pivot row {k}: the pivot value |U[{k},{k}]|={Math.Abs(u[k, k]):E2} is below the singularity threshold (1e-10). The matrix is singular or numerically near-singular. Verify the matrix is non-degenerate, or add regularization (A + εI) before decomposing.");
                     }
 
                     // Compute multipliers and eliminate
@@ -234,7 +237,9 @@ namespace DotCompute.Algorithms.LinearAlgebra.Operations
 
             if (!matrix.IsSquare)
             {
-                throw new ArgumentException("Matrix must be square for Cholesky decomposition.");
+                throw new ArgumentException(
+                    $"Cholesky decomposition requires a square symmetric positive-definite matrix (got {matrix.Rows}×{matrix.Columns}). For non-square inputs use QR or SVD.",
+                    nameof(matrix));
             }
 
             return await Task.Run(() =>
@@ -256,7 +261,8 @@ namespace DotCompute.Algorithms.LinearAlgebra.Operations
                             var value = matrix[j, j] - sum;
                             if (value <= 0)
                             {
-                                throw new InvalidOperationException("Matrix is not positive definite.");
+                                throw new InvalidOperationException(
+                                    "Cholesky decomposition failed: the input matrix is not positive definite (non-positive diagonal encountered). Cholesky requires A = LLᵀ with positive diagonals. Verify A is symmetric and positive definite, or use LU decomposition for general square matrices.");
                             }
                             l[j, j] = (float)Math.Sqrt(value);
                         }
@@ -291,7 +297,9 @@ namespace DotCompute.Algorithms.LinearAlgebra.Operations
 
             if (!matrix.IsSquare)
             {
-                throw new ArgumentException("Matrix must be square for eigenvalue decomposition.");
+                throw new ArgumentException(
+                    $"Eigenvalue decomposition requires a square matrix (got {matrix.Rows}×{matrix.Columns}). For rectangular matrices use SVD instead.",
+                    nameof(matrix));
             }
 
             return await Task.Run(() =>

--- a/src/Extensions/DotCompute.Algorithms/LinearAlgebra/Operations/MatrixOperations.cs
+++ b/src/Extensions/DotCompute.Algorithms/LinearAlgebra/Operations/MatrixOperations.cs
@@ -33,7 +33,9 @@ namespace DotCompute.Algorithms.LinearAlgebra.Operations
 
             if (a.Columns != b.Rows)
             {
-                throw new ArgumentException($"Matrix dimensions incompatible for multiplication: ({a.Rows}x{a.Columns}) * ({b.Rows}x{b.Columns})");
+                throw new ArgumentException(
+                    $"Matrix multiplication requires A.Columns == B.Rows (got A={a.Rows}×{a.Columns}, B={b.Rows}×{b.Columns}). Transpose one operand or reshape inputs. For element-wise multiplication, use Hadamard.",
+                    nameof(b));
             }
 
             var result = new Matrix(a.Rows, b.Columns);
@@ -67,7 +69,9 @@ namespace DotCompute.Algorithms.LinearAlgebra.Operations
 
             if (a.Rows != b.Rows || a.Columns != b.Columns)
             {
-                throw new ArgumentException($"Matrix dimensions must match for addition: ({a.Rows}x{a.Columns}) vs ({b.Rows}x{b.Columns})");
+                throw new ArgumentException(
+                    $"Matrix addition requires both operands to have identical dimensions (got A={a.Rows}×{a.Columns}, B={b.Rows}×{b.Columns}). Reshape or pad one matrix to match.",
+                    nameof(b));
             }
 
             // Use GPU for large matrices
@@ -120,7 +124,9 @@ namespace DotCompute.Algorithms.LinearAlgebra.Operations
 
             if (a.Rows != b.Rows || a.Columns != b.Columns)
             {
-                throw new ArgumentException($"Matrix dimensions must match for subtraction: ({a.Rows}x{a.Columns}) vs ({b.Rows}x{b.Columns})");
+                throw new ArgumentException(
+                    $"Matrix subtraction requires both operands to have identical dimensions (got A={a.Rows}×{a.Columns}, B={b.Rows}×{b.Columns}). Reshape or pad one matrix to match.",
+                    nameof(b));
             }
 
             // Use GPU for large matrices
@@ -252,7 +258,9 @@ namespace DotCompute.Algorithms.LinearAlgebra.Operations
 
             if (!matrix.IsSquare)
             {
-                throw new ArgumentException("Matrix must be square to compute inverse.");
+                throw new ArgumentException(
+                    $"Matrix inverse requires a square matrix (got {matrix.Rows}×{matrix.Columns}). Non-square matrices have no inverse — consider the Moore-Penrose pseudoinverse instead.",
+                    nameof(matrix));
             }
 
             // Use LU decomposition to compute inverse
@@ -293,7 +301,9 @@ namespace DotCompute.Algorithms.LinearAlgebra.Operations
 
             if (!matrix.IsSquare)
             {
-                throw new ArgumentException("Matrix must be square to compute determinant.");
+                throw new ArgumentException(
+                    $"Determinant is only defined for square matrices (got {matrix.Rows}×{matrix.Columns}). For non-square matrices, consider singular-value computations (SVD) or rank via pseudoinverse.",
+                    nameof(matrix));
             }
 
             if (matrix.Rows == 1)
@@ -402,7 +412,9 @@ namespace DotCompute.Algorithms.LinearAlgebra.Operations
 
                 if (!result.Success)
                 {
-                    throw new InvalidOperationException($"GPU execution failed: {result.ErrorMessage}");
+                    throw new InvalidOperationException(
+                        $"GPU execution failed on accelerator '{accelerator.Info.Name ?? accelerator.Info.Id}': {result.ErrorMessage ?? "<no message>"}. " +
+                        $"See kernel logs for detail. For large matrices, try reducing tile size, verifying input buffer sizes, or falling back to the CPU path.");
                 }
 
                 // Read results
@@ -440,7 +452,8 @@ namespace DotCompute.Algorithms.LinearAlgebra.Operations
             {
                 "Add" => "VectorAdd",
                 "Subtract" => "VectorSubtract",
-                _ => throw new NotSupportedException($"Operation {operation} not supported")
+                _ => throw new NotSupportedException(
+                    $"Matrix operation '{operation}' is not supported by MatrixOperations. Supported operations are Multiply, Add, Subtract, Transpose, Determinant, and Inverse.")
             };
 
             var kernel = await kernelManager.GetOrCompileOperationKernelAsync(
@@ -488,7 +501,9 @@ namespace DotCompute.Algorithms.LinearAlgebra.Operations
 
                 if (!result.Success)
                 {
-                    throw new InvalidOperationException($"GPU execution failed: {result.ErrorMessage}");
+                    throw new InvalidOperationException(
+                        $"GPU execution failed on accelerator '{accelerator.Info.Name ?? accelerator.Info.Id}': {result.ErrorMessage ?? "<no message>"}. " +
+                        $"See kernel logs for detail. For large matrices, try reducing tile size, verifying input buffer sizes, or falling back to the CPU path.");
                 }
 
                 await bufferResult.ReadAsync(resultData, 0, cancellationToken).ConfigureAwait(false);
@@ -696,7 +711,9 @@ namespace DotCompute.Algorithms.LinearAlgebra.Operations
 
                 if (!result.Success)
                 {
-                    throw new InvalidOperationException($"GPU execution failed: {result.ErrorMessage}");
+                    throw new InvalidOperationException(
+                        $"GPU execution failed on accelerator '{accelerator.Info.Name ?? accelerator.Info.Id}': {result.ErrorMessage ?? "<no message>"}. " +
+                        $"See kernel logs for detail. For large matrices, try reducing tile size, verifying input buffer sizes, or falling back to the CPU path.");
                 }
 
                 await bufferResult.ReadAsync(resultData, 0, cancellationToken).ConfigureAwait(false);

--- a/src/Extensions/DotCompute.Algorithms/Sparse/SparseMatrix.cs
+++ b/src/Extensions/DotCompute.Algorithms/Sparse/SparseMatrix.cs
@@ -79,11 +79,15 @@ public sealed class CsrMatrix<T> where T : unmanaged, INumber<T>
     {
         if (rowPointers.Length != rows + 1)
         {
-            throw new ArgumentException($"RowPointers length must be {rows + 1}, got {rowPointers.Length}");
+            throw new ArgumentException(
+                $"CSR rowPointers must have exactly rows+1={rows + 1} entries (got {rowPointers.Length}). The last entry equals NNZ (number of non-zeros) — re-check the CSR encoding.",
+                nameof(rowPointers));
         }
         if (values.Length != columnIndices.Length)
         {
-            throw new ArgumentException("Values and ColumnIndices must have same length");
+            throw new ArgumentException(
+                $"CSR values.Length ({values.Length}) must equal columnIndices.Length ({columnIndices.Length}) — each non-zero value needs a corresponding column index. Likely cause: array truncation or mis-slicing.",
+                nameof(columnIndices));
         }
 
         Rows = rows;
@@ -247,11 +251,13 @@ public sealed class CsrMatrix<T> where T : unmanaged, INumber<T>
     {
         if (row < 0 || row >= Rows)
         {
-            throw new ArgumentOutOfRangeException(nameof(row), $"Row {row} out of range [0, {Rows})");
+            throw new ArgumentOutOfRangeException(nameof(row), row,
+                $"Sparse matrix row index {row} is out of range [0, {Rows}) for this {Rows}×{Columns} matrix.");
         }
         if (col < 0 || col >= Columns)
         {
-            throw new ArgumentOutOfRangeException(nameof(col), $"Column {col} out of range [0, {Columns})");
+            throw new ArgumentOutOfRangeException(nameof(col), col,
+                $"Sparse matrix column index {col} is out of range [0, {Columns}) for this {Rows}×{Columns} matrix.");
         }
     }
 
@@ -259,7 +265,8 @@ public sealed class CsrMatrix<T> where T : unmanaged, INumber<T>
     {
         if (row < 0 || row >= Rows)
         {
-            throw new ArgumentOutOfRangeException(nameof(row), $"Row {row} out of range [0, {Rows})");
+            throw new ArgumentOutOfRangeException(nameof(row), row,
+                $"Sparse matrix row index {row} is out of range [0, {Rows}) for this {Rows}×{Columns} matrix.");
         }
     }
 }
@@ -289,11 +296,15 @@ public sealed class CscMatrix<T> where T : unmanaged, INumber<T>
     {
         if (columnPointers.Length != columns + 1)
         {
-            throw new ArgumentException($"ColumnPointers length must be {columns + 1}, got {columnPointers.Length}");
+            throw new ArgumentException(
+                $"CSC columnPointers must have exactly columns+1={columns + 1} entries (got {columnPointers.Length}). The last entry equals NNZ (number of non-zeros) — re-check the CSC encoding.",
+                nameof(columnPointers));
         }
         if (values.Length != rowIndices.Length)
         {
-            throw new ArgumentException("Values and RowIndices must have same length");
+            throw new ArgumentException(
+                $"CSC values.Length ({values.Length}) must equal rowIndices.Length ({rowIndices.Length}) — each non-zero value needs a corresponding row index. Likely cause: array truncation or mis-slicing.",
+                nameof(rowIndices));
         }
 
         Rows = rows;
@@ -428,7 +439,9 @@ public sealed class CooMatrix<T> where T : unmanaged, INumber<T>
     {
         if (values.Length != rowIndices.Length || values.Length != columnIndices.Length)
         {
-            throw new ArgumentException("Values, RowIndices, and ColumnIndices must have same length");
+            throw new ArgumentException(
+                $"COO coordinate-format arrays must all have the same length: values={values.Length}, rowIndices={rowIndices.Length}, columnIndices={columnIndices.Length}. Each non-zero requires matching (row, col, value) entries.",
+                nameof(values));
         }
 
         Rows = rows;
@@ -657,7 +670,9 @@ public static class SparseOps
     {
         if (a.Columns != x.Length)
         {
-            throw new ArgumentException($"Matrix columns ({a.Columns}) must match vector length ({x.Length})");
+            throw new ArgumentException(
+                $"SpMV dimension mismatch: matrix A is {a.Rows}×{a.Columns} but vector x has {x.Length} element(s). For y = A·x the number of columns in A must equal the length of x.",
+                nameof(x));
         }
 
         var y = new T[a.Rows];
@@ -683,7 +698,9 @@ public static class SparseOps
     {
         if (a.Columns != b.Rows)
         {
-            throw new ArgumentException($"Matrix dimensions don't match: ({a.Rows}×{a.Columns}) × ({b.Rows}×{b.Columns})");
+            throw new ArgumentException(
+                $"SpMM dimension mismatch: for C = A·B, A.Columns ({a.Columns}) must equal B.Rows ({b.Rows}). Got A={a.Rows}×{a.Columns} and B={b.Rows}×{b.Columns}. Transpose one operand or reshape inputs.",
+                nameof(b));
         }
 
         var builder = new SparseMatrixBuilder<T>(a.Rows, b.Columns);
@@ -730,7 +747,9 @@ public static class SparseOps
     {
         if (a.Rows != b.Rows || a.Columns != b.Columns)
         {
-            throw new ArgumentException($"Matrix dimensions must match: ({a.Rows}×{a.Columns}) vs ({b.Rows}×{b.Columns})");
+            throw new ArgumentException(
+                $"Sparse matrix addition requires identical dimensions: A={a.Rows}×{a.Columns}, B={b.Rows}×{b.Columns}. Reshape or pad one matrix to match, or choose SpMM for multiplication.",
+                nameof(b));
         }
 
         var builder = new SparseMatrixBuilder<T>(a.Rows, a.Columns);


### PR DESCRIPTION
## Summary

Wave-2 complement to [PR #136](https://github.com/mivertowski/DotCompute/pull/136). Expands **~205 throw sites across 78 files** so that every exception carries:

- The operation name / what failed (with arg values or current state).
- The owning type / method / identifier (kernel id, stream, device, context).
- A concrete next step for the user — often pointing at the right API call, DI registration, capacity knob, or diagnostic tool.

Target: messages that score 4/5 on the "useful when I see this at 3 AM in a log" scale, matching the bar set by PR #136.

### Areas covered

| Area | Files | Highlights |
| --- | --- | --- |
| `Core/Execution/*` | 25 | `ParallelExecutionStrategy`, `ResourceScheduler`, `ExecutionPlanFactory/Generator`, `LoadBalancer`, `WorkStealingCoordinator`, `ManagedCompiledKernel`, metrics, analysis, optimization, memory |
| `Core/Pipelines/*` | 14 | `KernelChainBuilder`, `PipelineMemoryManager`, `KernelPipeline/Builder`, pipeline memory bounds, stage validation, CustomSyncStrategy |
| `Core/Recovery/*` | 13 | `CircuitBreaker`, `ServiceCircuitState`, `GpuRecoveryManager`, `PluginRecoveryManager`, `PluginRecoveryConfiguration`, `MemoryRecoveryStrategy`, kernel/device monitors |
| `Core/Debugging/*` | 9 | `DebugServiceExtensions`, `DebugReportGenerator`, `KernelDebugValidator`, `KernelProfiler`, `KernelDebugOrchestrator`, `KernelDebugger`, `KernelValidator`, `EnhancedKernelValidator` |
| `CUDA/RingKernels/*` | 4 | `CudaRingKernelRuntime`, `CudaMessageQueue`, `GpuRingBuffer`, `TopicRegistryBuilder`, `RoutingTableBuilder` |
| `CUDA/Execution/*` | 7 | `CudaKernelExecutor`, `CudaStreamManager`, `CudaEventManager`, `CudaGraphSupport`, `CudaGraphManager`, `CudaGraph`, tensor-core managers |
| `Algorithms/*` | 4 | `Matrix`, `MatrixOperations`, `MatrixDecomposition`, `SparseMatrix` |

Deliberately **skipped** (per task scope): `Hopper/*`, `SystemInfoManager`, `Plugins/`, anything already in flight in PR #136, and the whole Metal backend (would double the scope).

### Before / after highlights

**1. Empty kernel chain**
```csharp
// Before (3/5)
throw new InvalidOperationException("Cannot execute empty kernel chain. Add at least one kernel step.");
// After (4/5)
throw new InvalidOperationException(
    "Kernel chain has no steps — ExecuteWithMetricsAsync requires at least one step. " +
    "Call Kernel(name, ...), Parallel(...), or Branch<T>(...) before ExecuteAsync/ExecuteWithMetricsAsync.");
```

**2. CUDA context setup failure**
```csharp
// Before
throw new InvalidOperationException(\$"Failed to retain primary CUDA context: {ctxResult}");
// After
throw new InvalidOperationException(
    \$"cuDevicePrimaryCtxRetain(device={device}) failed: {ctxResult} ({(int)ctxResult}). " +
    "The primary context cannot be retained — this usually indicates the device is busy, in an exclusive-process mode owned by another process, " +
    "or in a fatal error state. Run `nvidia-smi -q -d COMPUTE` to inspect compute mode.");
```

**3. Ring-kernel lifecycle mismatch**
```csharp
// Before
throw new InvalidOperationException(\$"Kernel '{kernelId}' not found");
// After
throw new InvalidOperationException(
    \$"Ring kernel '{kernelId}' was not found in the runtime. Currently registered kernels: [{string.Join(\", \", _kernels.Keys)}]. " +
    "Call LaunchAsync(kernelId, gridSize, blockSize) before Activate/Deactivate/Terminate.");
```

**4. Shared-memory type conflict**
```csharp
// Before
throw new InvalidOperationException(\$"Shared memory '{key}' exists but has incompatible type. Expected: {typeof(IPipelineMemory<T>).Name}, Actual: {existing.GetType().Name}");
// After
throw new InvalidOperationException(
    \$"Shared memory key '{key}' is already registered as {existing.GetType().Name}, but AllocateSharedAsync<{typeof(T).Name}> expects {typeof(IPipelineMemory<T>).Name}. " +
    "Shared-memory keys are unique per type — choose a distinct key for each element type, " +
    "or release the existing allocation before rebinding the key.");
```

**5. Tensor core unsupported data type**
```csharp
// Before
throw new NotSupportedException(\$"Data type {inputType} is not supported by tensor cores on this device");
// After
throw new NotSupportedException(
    \$"Tensor Core data type {inputType} is not supported on this CUDA device. Supported types on this device: " +
    \$"FP16={_capabilities.Fp16Supported}, BF16={_capabilities.Bf16Supported}, TF32={_capabilities.Tf32Supported}, " +
    \$"FP8={_capabilities.Fp8Supported}, INT8={_capabilities.Int8Supported}, INT4={_capabilities.Int4Supported}, FP64={_capabilities.Fp64Supported}. " +
    \"Choose a supported type or upgrade the GPU (Hopper CC 9.0 for FP8, Ampere CC 8.0 for BF16/TF32).\");
```

### Commits

- `b3afb25` – Core (execution / pipelines / recovery / debugging), ~135 throws across 61 files
- `fac9d83` – CUDA backend + Algorithms, ~70 throws across 17 files

### Tests

No tests assert on exact message text for any of the modified throws, so no test updates were needed. `Core.Tests` (486 passing) and `Backends.CPU.Tests` (25 passing) run clean with `--filter Category=Unit`. `Architecture.Tests` aborts with a test-host error on this branch and on `main` — pre-existing, unrelated to this PR.

## Test plan

- [x] `dotnet build DotCompute.sln --configuration Release` → 0 warnings, 0 errors
- [x] `./scripts/run-tests.sh DotCompute.sln --filter Category=Unit` → 511 tests pass (486 Core + 25 CPU)
- [ ] Spot-check one or two messages in a debugger to confirm the interpolated values render as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)