### PR TITLE
refactor: add IAsyncDisposable to async-managing types

### DIFF
--- a/src/Backends/DotCompute.Backends.CUDA/Persistent/CudaPersistentKernelManager.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/Persistent/CudaPersistentKernelManager.cs
@@ -14,7 +14,7 @@ namespace DotCompute.Backends.CUDA.Persistent
     /// <summary>
     /// Manages persistent, grid-resident CUDA kernels for long-running computations.
     /// </summary>
-    public sealed partial class CudaPersistentKernelManager : IDisposable
+    public sealed partial class CudaPersistentKernelManager : IDisposable, IAsyncDisposable
     {
         #region LoggerMessage Delegates
 
@@ -337,6 +337,43 @@ namespace DotCompute.Backends.CUDA.Persistent
             _ringBufferAllocator?.Dispose();
             _disposed = true;
         }
+
+        /// <summary>
+        /// Asynchronously disposes the persistent kernel manager, awaiting the
+        /// shutdown of every active persistent kernel before releasing the
+        /// ring-buffer allocator.
+        /// </summary>
+        /// <remarks>
+        /// Prefer this over <see cref="Dispose"/> in async teardown: each
+        /// <c>StopKernelAsync</c> is awaited rather than resolved via
+        /// <c>GetAwaiter().GetResult()</c>, so a kernel that takes non-trivial
+        /// time to drain its command queue does not block a thread-pool thread.
+        /// </remarks>
+        public async ValueTask DisposeAsync()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            // Stop all active kernels cooperatively.
+            foreach (var kernelId in _activeKernels.Keys)
+            {
+                try
+                {
+                    await StopKernelAsync(kernelId).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    LogKernelStopError(_logger, ex);
+                }
+            }
+
+            _ringBufferAllocator?.Dispose();
+            _disposed = true;
+
+            GC.SuppressFinalize(this);
+        }
         /// <summary>
         /// A class that represents persistent kernel state.
         /// </summary>
@@ -401,7 +438,7 @@ namespace DotCompute.Backends.CUDA.Persistent
     /// <summary>
     /// Handle for interacting with a running persistent kernel.
     /// </summary>
-    public interface IPersistentKernelHandle : IDisposable
+    public interface IPersistentKernelHandle : IDisposable, IAsyncDisposable
     {
         /// <summary>
         /// Gets or sets the kernel identifier.
@@ -511,6 +548,24 @@ namespace DotCompute.Backends.CUDA.Persistent
             {
                 // Swallow exceptions during dispose
             }
+        }
+
+        /// <summary>
+        /// Asynchronously stops the kernel and releases resources without
+        /// blocking the caller's thread.
+        /// </summary>
+        public async ValueTask DisposeAsync()
+        {
+            try
+            {
+                await StopAsync().ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                // Swallow exceptions during dispose
+            }
+
+            GC.SuppressFinalize(this);
         }
     }
 

--- a/src/Backends/DotCompute.Backends.CUDA/Profiling/CudaPerformanceProfiler.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/Profiling/CudaPerformanceProfiler.cs
@@ -16,7 +16,7 @@ namespace DotCompute.Backends.CUDA.Profiling
     /// Production-grade CUDA performance profiler with CUPTI integration,
     /// metrics collection, and detailed performance analysis.
     /// </summary>
-    public sealed partial class CudaPerformanceProfiler : IDisposable
+    public sealed partial class CudaPerformanceProfiler : IDisposable, IAsyncDisposable
     {
         private readonly ILogger<CudaPerformanceProfiler> _logger;
         private readonly ConcurrentDictionary<string, KernelProfile> _kernelProfiles;
@@ -785,6 +785,57 @@ namespace DotCompute.Backends.CUDA.Profiling
             }
 
             _disposed = true;
+        }
+
+        /// <summary>
+        /// Asynchronously disposes the profiler, awaiting any active profiling
+        /// session's stop-and-drain instead of blocking the calling thread.
+        /// </summary>
+        /// <remarks>
+        /// Prefer this over <see cref="Dispose"/> in async shutdown paths: when
+        /// profiling is active, <c>StopProfilingAsync</c> is awaited rather than
+        /// resolved via <c>GetAwaiter().GetResult()</c>, so a long-running flush
+        /// of CUPTI buffers does not stall the caller's thread pool worker.
+        /// </remarks>
+        public async ValueTask DisposeAsync()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _metricsTimer?.Dispose();
+            _profilingLock?.Dispose();
+
+            if (_isProfilingActive)
+            {
+                try
+                {
+                    _ = await StopProfilingAsync().ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    Trace.TraceWarning($"StopProfilingAsync failed during async disposal: {ex.Message}");
+                }
+            }
+
+            if (_cuptiSubscriber != IntPtr.Zero)
+            {
+                _ = cuptiUnsubscribe(_cuptiSubscriber);
+            }
+
+            try
+            {
+                _ = nvmlShutdown();
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceWarning($"NVML shutdown failed: {ex.Message}");
+            }
+
+            _disposed = true;
+
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Backends/DotCompute.Backends.Metal/MetalBackend.LoggerMessages.cs
+++ b/src/Backends/DotCompute.Backends.Metal/MetalBackend.LoggerMessages.cs
@@ -166,4 +166,10 @@ public partial class MetalBackend
         Level = LogLevel.Error,
         Message = "Failed to create Metal accelerator for device {DeviceIndex}")]
     private static partial void LogAcceleratorCreationError(ILogger logger, Exception ex, int deviceIndex);
+
+    [LoggerMessage(
+        EventId = 3002,
+        Level = LogLevel.Warning,
+        Message = "Failed to dispose Metal accelerator during backend shutdown")]
+    private static partial void LogAcceleratorDisposeError(ILogger logger, Exception ex);
 }

--- a/src/Backends/DotCompute.Backends.Metal/MetalBackend.cs
+++ b/src/Backends/DotCompute.Backends.Metal/MetalBackend.cs
@@ -17,7 +17,7 @@ namespace DotCompute.Backends.Metal;
 /// <summary>
 /// Main entry point for Metal compute backend
 /// </summary>
-public sealed partial class MetalBackend : IDisposable
+public sealed partial class MetalBackend : IDisposable, IAsyncDisposable
 {
     private readonly ILogger<MetalBackend> _logger;
     private readonly ILoggerFactory _loggerFactory;
@@ -493,6 +493,46 @@ public sealed partial class MetalBackend : IDisposable
 #pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             accelerator?.DisposeAsync().AsTask().GetAwaiter().GetResult();
 #pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
+        }
+
+        _accelerators.Clear();
+        _disposed = true;
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Asynchronously disposes the backend by awaiting each Metal accelerator's
+    /// <see cref="IAsyncDisposable.DisposeAsync"/> in sequence.
+    /// </summary>
+    /// <remarks>
+    /// Prefer this over <see cref="Dispose"/> in async hosts: Metal accelerators
+    /// hold command queues, buffer pools, and MPS handles whose clean shutdown
+    /// involves asynchronous work. Awaiting here avoids the
+    /// <c>AsTask().GetAwaiter().GetResult()</c> sync-over-async pattern and
+    /// prevents thread-pool starvation during multi-GPU teardown.
+    /// </remarks>
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        foreach (var accelerator in _accelerators)
+        {
+            if (accelerator is null)
+            {
+                continue;
+            }
+
+            try
+            {
+                await accelerator.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                LogAcceleratorDisposeError(_logger, ex);
+            }
         }
 
         _accelerators.Clear();

--- a/src/Core/DotCompute.Core/Logging/LogBuffer.cs
+++ b/src/Core/DotCompute.Core/Logging/LogBuffer.cs
@@ -13,7 +13,7 @@ namespace DotCompute.Core.Logging;
 /// High-performance asynchronous log buffer with batching, compression, and multiple sink support.
 /// Designed to minimize performance impact on the main application thread while ensuring reliable log delivery.
 /// </summary>
-public sealed partial class LogBuffer : IDisposable
+public sealed partial class LogBuffer : IDisposable, IAsyncDisposable
 {
     #region LoggerMessage Delegates
 
@@ -620,6 +620,87 @@ public sealed partial class LogBuffer : IDisposable
             _flushSemaphore?.Dispose();
             _cancellationTokenSource?.Dispose();
         }
+    }
+
+    /// <summary>
+    /// Asynchronously disposes the log buffer, completing the channel writer,
+    /// awaiting the processing task, and performing a final flush without
+    /// blocking the calling thread.
+    /// </summary>
+    /// <remarks>
+    /// Prefer this over <see cref="Dispose"/> when shutting down inside an
+    /// async scope (host teardown, test cleanup): the background processing
+    /// task is awaited rather than <c>Wait(TimeSpan)</c>'d, and the final
+    /// flush happens asynchronously, so shutdown does not stall an async
+    /// thread pool worker.
+    /// </remarks>
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        try
+        {
+            // Stop accepting new entries.
+            _writer.Complete();
+
+            // Cancel background processing.
+            await _cancellationTokenSource.CancelAsync().ConfigureAwait(false);
+
+            // Await the background processing task (bounded by a timeout so
+            // a wedged processor cannot hang shutdown).
+            try
+            {
+                await _processingTask.WaitAsync(TimeSpan.FromSeconds(30)).ConfigureAwait(false);
+            }
+            catch (TimeoutException)
+            {
+                _logger.LogWarningMessage("Log processing task did not complete within timeout");
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected when the processing task observes cancellation.
+            }
+
+            // Final flush, awaited rather than sync-over-async.
+            try
+            {
+                await FlushAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogErrorMessage(ex, "Error during final LogBuffer flush");
+            }
+
+            // Dispose sinks. ILogSink is IDisposable today; this matches Dispose().
+            foreach (var sink in _sinks)
+            {
+                try
+                {
+                    sink.Dispose();
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogErrorMessage(ex, $"Error disposing sink: {sink.GetType().Name}");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogErrorMessage(ex, "Error during LogBuffer async disposal");
+        }
+        finally
+        {
+            _batchTimer?.Dispose();
+            _flushSemaphore?.Dispose();
+            _cancellationTokenSource?.Dispose();
+        }
+
+        GC.SuppressFinalize(this);
     }
 }
 /// <summary>

--- a/src/Core/DotCompute.Core/Logging/StructuredLogger.cs
+++ b/src/Core/DotCompute.Core/Logging/StructuredLogger.cs
@@ -11,7 +11,7 @@ namespace DotCompute.Core.Logging;
 /// Production-grade structured logger with semantic properties, correlation IDs, and performance metrics.
 /// Provides async, buffered logging with configurable sinks and minimal performance impact.
 /// </summary>
-public sealed partial class StructuredLogger : ILogger, IDisposable
+public sealed partial class StructuredLogger : ILogger, IDisposable, IAsyncDisposable
 {
     private readonly string _categoryName;
     private readonly ILogger _baseLogger;
@@ -608,6 +608,40 @@ public sealed partial class StructuredLogger : ILogger, IDisposable
 
 
         _flushTimer?.Dispose();
+    }
+
+    /// <summary>
+    /// Asynchronously disposes the logger, performing a final flush of the underlying
+    /// <see cref="LogBuffer"/> without blocking the calling thread.
+    /// </summary>
+    /// <remarks>
+    /// Prefer this over <see cref="Dispose"/> in async hosts: the buffered channel is
+    /// drained via <see cref="LogBuffer.DisposeAsync"/> rather than a sync-over-async
+    /// <c>FlushAsync().GetAwaiter().GetResult()</c>, so the processing task can complete
+    /// cleanly without starving the thread pool during shutdown.
+    /// </remarks>
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        try
+        {
+            // Flush and shut down the buffer cooperatively.
+            await _logBuffer.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            LogFinalFlushFailed(_baseLogger, ex);
+        }
+
+        _flushTimer?.Dispose();
+
+        GC.SuppressFinalize(this);
     }
 }
 /// <summary>

--- a/src/Core/DotCompute.Core/Security/MemoryProtection.cs
+++ b/src/Core/DotCompute.Core/Security/MemoryProtection.cs
@@ -18,7 +18,7 @@ namespace DotCompute.Core.Security;
 /// Provides comprehensive memory protection services including bounds checking,
 /// guard pages, and secure memory management with defense against common memory vulnerabilities.
 /// </summary>
-public sealed partial class MemoryProtection : IDisposable
+public sealed partial class MemoryProtection : IDisposable, IAsyncDisposable
 {
     private readonly ILogger _logger;
     private readonly MemoryProtectionConfiguration _configuration;
@@ -895,6 +895,52 @@ public sealed partial class MemoryProtection : IDisposable
         _allocations.Clear();
 
         _logger.LogInfoMessage($"MemoryProtection disposed. Final statistics: Allocations={_allocations.Count}, Violations={_violationCount}");
+    }
+
+    /// <summary>
+    /// Asynchronously disposes the memory protection service, awaiting secure
+    /// wipes of any protected regions before releasing their backing memory.
+    /// </summary>
+    /// <remarks>
+    /// Prefer this over <see cref="Dispose"/> when disposing during async
+    /// shutdown: each region's secure wipe is awaited rather than resolved via
+    /// <c>GetAwaiter().GetResult()</c>, which avoids blocking the thread pool
+    /// when many regions need to be scrubbed.
+    /// </remarks>
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        _integrityCheckTimer?.Dispose();
+        _allocationLock?.Dispose();
+
+        foreach (var region in _protectedRegions.Values)
+        {
+            try
+            {
+                if (_configuration.EnableSecureWiping)
+                {
+                    await SecureWipeMemoryAsync(region).ConfigureAwait(false);
+                }
+                FreeRawMemory(region.BaseAddress, region.TotalSize);
+            }
+            catch (Exception ex)
+            {
+                MemoryRegionDisposeError(_logger, ex, region.Identifier);
+            }
+        }
+
+        _protectedRegions.Clear();
+        _allocations.Clear();
+
+        _logger.LogInfoMessage($"MemoryProtection disposed. Final statistics: Allocations={_allocations.Count}, Violations={_violationCount}");
+
+        GC.SuppressFinalize(this);
     }
 }
 

--- a/src/Core/DotCompute.Core/Security/MemorySanitizer.cs
+++ b/src/Core/DotCompute.Core/Security/MemorySanitizer.cs
@@ -22,7 +22,7 @@ namespace DotCompute.Core.Security;
 /// with advanced security features for protecting sensitive data in memory.
 /// Implements production-grade memory safety with hardware-accelerated validation.
 /// </summary>
-public sealed partial class MemorySanitizer : IDisposable
+public sealed partial class MemorySanitizer : IDisposable, IAsyncDisposable
 {
     private readonly ILogger _logger;
     private readonly MemorySanitizerConfiguration _configuration;
@@ -1084,6 +1084,56 @@ public sealed partial class MemorySanitizer : IDisposable
 
         var stats = GetStatistics();
         LogSanitizerDisposed(_logger, stats.TotalAllocations, stats.TotalViolations);
+    }
+
+    /// <summary>
+    /// Asynchronously disposes the sanitizer, awaiting secure wipes of any
+    /// tracked allocations before releasing their backing memory.
+    /// </summary>
+    /// <remarks>
+    /// Prefer this over <see cref="Dispose"/> in async shutdown paths: each
+    /// tracked allocation's secure wipe is awaited rather than resolved via
+    /// <c>GetAwaiter().GetResult()</c>, which prevents starving the thread pool
+    /// when many allocations need to be scrubbed at once.
+    /// </remarks>
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        // Secure-wipe + free each tracked allocation asynchronously.
+        foreach (var allocation in _trackedAllocations.Values)
+        {
+            try
+            {
+                if (_configuration.EnableSecureWiping)
+                {
+                    await PerformSecureWipeAsync(allocation).ConfigureAwait(false);
+                }
+                FreeRawMemory(allocation.BaseAddress, allocation.TotalSize);
+            }
+            catch (Exception ex)
+            {
+                LogAllocationDisposeError(_logger, ex, allocation.Identifier);
+            }
+        }
+
+        _trackedAllocations.Clear();
+        _freeHistory.Clear();
+
+        _leakDetectionTimer?.Dispose();
+        _integrityCheckTimer?.Dispose();
+        _operationLock?.Dispose();
+        _randomGenerator?.Dispose();
+
+        var stats = GetStatistics();
+        LogSanitizerDisposed(_logger, stats.TotalAllocations, stats.TotalViolations);
+
+        GC.SuppressFinalize(this);
     }
 }
 

--- a/src/Extensions/DotCompute.Algorithms/Security/KernelSandbox.cs
+++ b/src/Extensions/DotCompute.Algorithms/Security/KernelSandbox.cs
@@ -15,7 +15,7 @@ namespace DotCompute.Algorithms.Security;
 /// Provides sandboxed execution environment for untrusted kernels with comprehensive security controls.
 /// Implements process isolation, resource limits, and execution monitoring.
 /// </summary>
-public sealed partial class KernelSandbox : IDisposable
+public sealed partial class KernelSandbox : IDisposable, IAsyncDisposable
 {
     private readonly ILogger _logger;
     private readonly SandboxConfiguration _configuration;
@@ -544,6 +544,54 @@ public sealed partial class KernelSandbox : IDisposable
 
 
         _logger.LogInfoMessage("KernelSandbox disposed");
+    }
+
+    /// <summary>
+    /// Asynchronously disposes the sandbox, awaiting each active sandbox's
+    /// cooperative teardown before releasing the monitoring timer and
+    /// creation lock.
+    /// </summary>
+    /// <remarks>
+    /// Prefer this over <see cref="Dispose"/> in async shutdown paths:
+    /// destroying each sandbox spawns a process-kill-and-cleanup task; awaiting
+    /// them via <see cref="Task.WhenAll(IEnumerable{Task})"/> instead of
+    /// <see cref="Task.WaitAll(Task[], TimeSpan)"/> avoids parking a
+    /// thread-pool worker for up to 30 seconds while many sandboxes unwind.
+    /// </remarks>
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        _monitoringTimer?.Dispose();
+        _creationLock?.Dispose();
+
+        var sandboxTasks = _activeSandboxes.Keys
+            .Select(DestroySandboxInstanceAsync)
+            .ToArray();
+
+        try
+        {
+            await Task.WhenAll(sandboxTasks)
+                .WaitAsync(TimeSpan.FromSeconds(30))
+                .ConfigureAwait(false);
+        }
+        catch (TimeoutException ex)
+        {
+            _logger.LogErrorMessage(ex, "Timeout async-disposing sandboxes");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogErrorMessage(ex, "Error async-disposing sandboxes");
+        }
+
+        _logger.LogInfoMessage("KernelSandbox async-disposed");
+
+        GC.SuppressFinalize(this);
     }
 
     #region LoggerMessage Delegates

--- a/src/Extensions/DotCompute.Linq/CodeGeneration/CompilationPipeline.cs
+++ b/src/Extensions/DotCompute.Linq/CodeGeneration/CompilationPipeline.cs
@@ -44,7 +44,7 @@ namespace DotCompute.Linq.CodeGeneration;
 /// The internal Roslyn workspace is reused across compilations for efficiency.
 /// </para>
 /// </remarks>
-public sealed class CompilationPipeline : IDisposable
+public sealed class CompilationPipeline : IDisposable, IAsyncDisposable
 {
     private readonly IKernelCache _kernelCache;
     private readonly CpuKernelGenerator _kernelGenerator;
@@ -986,6 +986,47 @@ public static class KernelArrayWrapper
             Interlocked.Read(ref _cacheHits),
             Interlocked.Read(ref _compilationFailures),
             Interlocked.Read(ref _fallbackCount));
+    }
+
+    /// <summary>
+    /// Asynchronously disposes the compilation pipeline, awaiting the CUDA
+    /// and Metal runtime compilers' cooperative shutdown so their semaphores
+    /// and cached kernels release without blocking the calling thread.
+    /// </summary>
+    /// <remarks>
+    /// Prefer this over <see cref="Dispose"/> in async shutdown paths: the
+    /// CUDA and Metal compilers each own a <see cref="SemaphoreSlim"/> guarding
+    /// compilation state and a dictionary of cached compiled kernels that may
+    /// implement <see cref="IAsyncDisposable"/>. Awaiting their
+    /// <see cref="IAsyncDisposable.DisposeAsync"/> drains both cooperatively.
+    /// </remarks>
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        if (_cudaCompiler is not null)
+        {
+            await _cudaCompiler.DisposeAsync().ConfigureAwait(false);
+        }
+
+        if (_metalCompiler is not null)
+        {
+            await _metalCompiler.DisposeAsync().ConfigureAwait(false);
+        }
+
+        _logger?.LogInformation(
+            "CompilationPipeline async-disposed. Stats - Total: {Total}, Cache Hits: {Hits}, Failures: {Failures}, Fallbacks: {Fallbacks}",
+            Interlocked.Read(ref _totalCompilations),
+            Interlocked.Read(ref _cacheHits),
+            Interlocked.Read(ref _compilationFailures),
+            Interlocked.Read(ref _fallbackCount));
+
+        GC.SuppressFinalize(this);
     }
 }
 

--- a/src/Extensions/DotCompute.Linq/CodeGeneration/RuntimeExecutor.cs
+++ b/src/Extensions/DotCompute.Linq/CodeGeneration/RuntimeExecutor.cs
@@ -37,7 +37,7 @@ namespace DotCompute.Linq.CodeGeneration;
 /// <item><description>Execute compiled GPU kernels on the appropriate accelerator</description></item>
 /// </list>
 /// </remarks>
-public sealed class RuntimeExecutor : IDisposable
+public sealed class RuntimeExecutor : IDisposable, IAsyncDisposable
 {
     private readonly ILogger<RuntimeExecutor> _logger;
     private readonly Dictionary<ComputeBackend, IAccelerator> _accelerators = new();
@@ -542,5 +542,40 @@ public sealed class RuntimeExecutor : IDisposable
         _disposed = true;
 
         _logger.LogInformation("RuntimeExecutor disposed");
+    }
+
+    /// <summary>
+    /// Asynchronously disposes all accelerators and releases resources.
+    /// </summary>
+    /// <remarks>
+    /// Prefer this over <see cref="Dispose"/> in async shutdown paths: each
+    /// accelerator's <see cref="IAsyncDisposable.DisposeAsync"/> is awaited
+    /// directly instead of resolved via <c>AsTask().Wait()</c>, so long-running
+    /// resource cleanup (stream synchronization, memory pool trimming) does
+    /// not block the calling thread.
+    /// </remarks>
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
+
+        foreach (var accelerator in _accelerators.Values)
+        {
+            try
+            {
+                await accelerator.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error async-disposing accelerator: {Name}", accelerator.Info.Name);
+            }
+        }
+
+        _accelerators.Clear();
+        _initLock.Dispose();
+        _disposed = true;
+
+        _logger.LogInformation("RuntimeExecutor async-disposed");
+
+        GC.SuppressFinalize(this);
     }
 }

--- a/src/Extensions/DotCompute.Linq/Compilation/CudaRuntimeKernelCompiler.cs
+++ b/src/Extensions/DotCompute.Linq/Compilation/CudaRuntimeKernelCompiler.cs
@@ -45,7 +45,7 @@ namespace DotCompute.Linq.Compilation;
 /// <item><description>Production-ready error handling and fallback to CPU</description></item>
 /// </list>
 /// </remarks>
-public sealed class CudaRuntimeKernelCompiler : IGpuKernelCompiler, IDisposable
+public sealed class CudaRuntimeKernelCompiler : IGpuKernelCompiler, IDisposable, IAsyncDisposable
 {
     private readonly ILogger<CudaRuntimeKernelCompiler> _logger;
     private readonly CudaAccelerator _accelerator;
@@ -310,6 +310,54 @@ public sealed class CudaRuntimeKernelCompiler : IGpuKernelCompiler, IDisposable
             _compilationLock.Dispose();
             _disposed = true;
         }
+    }
+
+    /// <summary>
+    /// Asynchronously disposes the CUDA runtime kernel compiler, acquiring
+    /// the compilation semaphore cooperatively so in-flight compilation calls
+    /// can drain before cached kernels are released.
+    /// </summary>
+    /// <remarks>
+    /// Prefer this over <see cref="Dispose"/> in async shutdown paths: the
+    /// compilation semaphore is acquired via
+    /// <see cref="SemaphoreSlim.WaitAsync()"/> instead of a blocking
+    /// <see cref="SemaphoreSlim.Wait()"/>, and any cached kernels that
+    /// implement <see cref="IAsyncDisposable"/> are awaited rather than
+    /// sync-disposed. This avoids starving the thread pool when a concurrent
+    /// <c>CompileKernelAsync</c> holds the semaphore.
+    /// </remarks>
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
+
+        await _compilationLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            foreach (var kernel in _compiledKernels.Values)
+            {
+                if (kernel is IAsyncDisposable asyncKernel)
+                {
+                    await asyncKernel.DisposeAsync().ConfigureAwait(false);
+                }
+                else
+                {
+                    (kernel as IDisposable)?.Dispose();
+                }
+            }
+
+            _compiledKernels.Clear();
+
+            _logger.LogInformation("CudaRuntimeKernelCompiler async-disposed ({Count} cached kernels cleaned up)",
+                _compiledKernels.Count);
+        }
+        finally
+        {
+            _ = _compilationLock.Release();
+            _compilationLock.Dispose();
+            _disposed = true;
+        }
+
+        GC.SuppressFinalize(this);
     }
 }
 

--- a/src/Extensions/DotCompute.Linq/Compilation/MetalRuntimeKernelCompiler.cs
+++ b/src/Extensions/DotCompute.Linq/Compilation/MetalRuntimeKernelCompiler.cs
@@ -44,7 +44,7 @@ namespace DotCompute.Linq.Compilation;
 /// <item><description>iOS/iPadOS devices (A-series chips)</description></item>
 /// </list>
 /// </remarks>
-public sealed class MetalRuntimeKernelCompiler : IGpuKernelCompiler, IDisposable
+public sealed class MetalRuntimeKernelCompiler : IGpuKernelCompiler, IDisposable, IAsyncDisposable
 {
     private readonly ILogger<MetalRuntimeKernelCompiler> _logger;
     private readonly MetalAccelerator _accelerator;
@@ -304,6 +304,53 @@ public sealed class MetalRuntimeKernelCompiler : IGpuKernelCompiler, IDisposable
             _compilationLock.Dispose();
             _disposed = true;
         }
+    }
+
+    /// <summary>
+    /// Asynchronously disposes the Metal runtime kernel compiler, acquiring
+    /// the compilation semaphore cooperatively so in-flight compilation calls
+    /// can drain before cached kernels are released.
+    /// </summary>
+    /// <remarks>
+    /// Prefer this over <see cref="Dispose"/> in async shutdown paths: the
+    /// compilation semaphore is acquired via
+    /// <see cref="SemaphoreSlim.WaitAsync()"/> instead of a blocking
+    /// <see cref="SemaphoreSlim.Wait()"/>, and any cached kernels that
+    /// implement <see cref="IAsyncDisposable"/> are awaited rather than
+    /// sync-disposed.
+    /// </remarks>
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
+
+        await _compilationLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            foreach (var kernel in _compiledKernels.Values)
+            {
+                if (kernel is IAsyncDisposable asyncKernel)
+                {
+                    await asyncKernel.DisposeAsync().ConfigureAwait(false);
+                }
+                else
+                {
+                    (kernel as IDisposable)?.Dispose();
+                }
+            }
+
+            _compiledKernels.Clear();
+
+            _logger.LogInformation("MetalRuntimeKernelCompiler async-disposed ({Count} cached kernels cleaned up)",
+                _compiledKernels.Count);
+        }
+        finally
+        {
+            _ = _compilationLock.Release();
+            _compilationLock.Dispose();
+            _disposed = true;
+        }
+
+        GC.SuppressFinalize(this);
     }
 }
 

--- a/src/Extensions/DotCompute.Linq/Reactive/BackpressureManager.cs
+++ b/src/Extensions/DotCompute.Linq/Reactive/BackpressureManager.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
 namespace DotCompute.Linq.Reactive;
@@ -20,7 +21,7 @@ namespace DotCompute.Linq.Reactive;
 /// - Block: Block producer thread until space available
 /// - Sample: Keep only most recent item
 /// </remarks>
-public sealed class BackpressureManager : IBackpressureManager, IDisposable
+public sealed class BackpressureManager : IBackpressureManager, IDisposable, IAsyncDisposable
 {
     private readonly ILogger<BackpressureManager> _logger;
 
@@ -361,18 +362,80 @@ public sealed class BackpressureManager : IBackpressureManager, IDisposable
 
     #endregion
 
-    #region IDisposable
+    #region IDisposable / IAsyncDisposable
+
+    private int _disposed;
 
     /// <summary>
     /// Disposes resources used by the backpressure manager.
     /// </summary>
     public void Dispose()
     {
-        _cancellationSource.Cancel();
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        DisposeCore();
+    }
+
+    /// <summary>
+    /// Asynchronously disposes resources used by the backpressure manager.
+    /// </summary>
+    /// <remarks>
+    /// Cancels the cancellation source, unblocks any producer threads waiting on
+    /// <see cref="BackpressureStrategy.Block"/>, and drains the pending buffer before
+    /// releasing resources. Prefer this over <see cref="Dispose"/> when running inside
+    /// async contexts so producers observe cancellation cleanly before shutdown.
+    /// </remarks>
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            await _cancellationSource.CancelAsync().ConfigureAwait(false);
+        }
+        catch (ObjectDisposedException)
+        {
+            // Already disposed - nothing to cancel.
+        }
+
+        // Wake any producers blocked in HandleBlock so they can observe cancellation
+        // before we tear the manager down.
+        UnblockProducer();
+
+        // Drain pending items so subscribers that still hold a reference see an
+        // empty buffer rather than a half-populated snapshot after disposal.
+        while (_buffer.TryDequeue(out _))
+        {
+        }
+
         _cancellationSource.Dispose();
+
+        _logger.LogInformation("BackpressureManager disposed. " +
+            "Total processed: {Processed}, Total dropped: {Dropped}",
+            _totalItemsProcessed, _totalItemsDropped);
+    }
+
+    private void DisposeCore()
+    {
+        try
+        {
+            _cancellationSource.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // Already disposed - nothing to cancel.
+        }
 
         // Unblock any waiting threads
         UnblockProducer();
+
+        _cancellationSource.Dispose();
 
         _logger.LogInformation("BackpressureManager disposed. " +
             "Total processed: {Processed}, Total dropped: {Dropped}",

--- a/src/Runtime/DotCompute.Plugins/Managers/NuGetPluginManager.cs
+++ b/src/Runtime/DotCompute.Plugins/Managers/NuGetPluginManager.cs
@@ -17,7 +17,7 @@ namespace DotCompute.Plugins.Managers;
 /// <summary>
 /// Advanced NuGet plugin manager with comprehensive lifecycle management, hot reloading, and monitoring.
 /// </summary>
-public class NuGetPluginManager : IDisposable
+public class NuGetPluginManager : IDisposable, IAsyncDisposable
 {
     private readonly ILogger<NuGetPluginManager> _logger;
     private readonly NuGetPluginLoader _pluginLoader;
@@ -666,6 +666,49 @@ public class NuGetPluginManager : IDisposable
             catch (Exception ex)
             {
                 _logger.LogErrorMessage(ex, $"Error unloading plugin during dispose: {pluginId}");
+            }
+        }
+
+        _pluginLoader?.Dispose();
+        _healthMonitor?.Dispose();
+        _metricsCollector?.Dispose();
+        _operationSemaphore?.Dispose();
+
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Asynchronously disposes the plugin manager, awaiting each plugin's
+    /// unload before tearing down the loader, health monitor, and metrics
+    /// collector.
+    /// </summary>
+    /// <remarks>
+    /// Prefer this over <see cref="Dispose"/> during async host shutdown:
+    /// <c>UnloadPluginAsync</c> is awaited rather than resolved via
+    /// <c>GetAwaiter().GetResult()</c>, so long-running unload hooks (plugin
+    /// finalisation, terminator scripts) do not block a thread-pool worker.
+    /// </remarks>
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        _periodicMaintenanceTimer?.Dispose();
+
+        // Unload all plugins cooperatively.
+        foreach (var (pluginId, _) in _managedPlugins.ToList())
+        {
+            try
+            {
+                _ = await UnloadPluginAsync(pluginId).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogErrorMessage(ex, $"Error unloading plugin during async dispose: {pluginId}");
             }
         }
 

--- a/src/Runtime/DotCompute.Plugins/Security/PluginSandbox.cs
+++ b/src/Runtime/DotCompute.Plugins/Security/PluginSandbox.cs
@@ -12,7 +12,7 @@ namespace DotCompute.Plugins.Security;
 /// <summary>
 /// Provides secure sandboxing and isolation for plugin execution with controlled permissions.
 /// </summary>
-public class PluginSandbox : IDisposable
+public class PluginSandbox : IDisposable, IAsyncDisposable
 {
     private readonly ILogger<PluginSandbox> _logger;
     private readonly SandboxConfiguration _configuration;
@@ -460,6 +460,44 @@ public class PluginSandbox : IDisposable
             catch (Exception ex)
             {
                 _logger.LogErrorMessage(ex, $"Error disposing sandboxed plugin {plugin.Id}");
+            }
+        }
+
+        _sandboxedPlugins.Clear();
+        _resourceMonitor?.Dispose();
+        _securityManager?.Dispose();
+    }
+
+    /// <summary>
+    /// Asynchronously disposes the sandbox, awaiting each sandboxed plugin's
+    /// termination before releasing the security manager and resource monitor.
+    /// </summary>
+    /// <remarks>
+    /// Prefer this over <see cref="Dispose"/> in async contexts: plugin
+    /// termination runs cooperative cleanup hooks that previously resolved via
+    /// <c>GetAwaiter().GetResult()</c>, which can deadlock under hosts with a
+    /// captured synchronization context and starve the thread pool when many
+    /// plugins are active.
+    /// </remarks>
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        GC.SuppressFinalize(this);
+
+        foreach (var plugin in _sandboxedPlugins.Values)
+        {
+            try
+            {
+                await plugin.TerminateAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogErrorMessage(ex, $"Error async-disposing sandboxed plugin {plugin.Id}");
             }
         }
 

--- a/src/Runtime/DotCompute.Plugins/Security/SandboxedPlugin.cs
+++ b/src/Runtime/DotCompute.Plugins/Security/SandboxedPlugin.cs
@@ -6,7 +6,7 @@ namespace DotCompute.Plugins.Security;
 /// <summary>
 /// Represents a plugin running in a secure sandbox with restricted permissions.
 /// </summary>
-public class SandboxedPlugin : IDisposable
+public class SandboxedPlugin : IDisposable, IAsyncDisposable
 {
     private readonly ResourceMonitor _resourceMonitor;
     private bool _disposed;
@@ -173,6 +173,37 @@ public class SandboxedPlugin : IDisposable
 
         _disposed = true;
         TerminateAsync().GetAwaiter().GetResult();
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Asynchronously disposes the sandboxed plugin, awaiting its termination
+    /// hooks before releasing the isolated load context and resource monitor.
+    /// </summary>
+    /// <remarks>
+    /// Prefer this over <see cref="Dispose"/> in async contexts: plugin
+    /// termination runs sensitive cleanup (flushing outstanding operations,
+    /// clearing cached data) that previously resolved via
+    /// <c>GetAwaiter().GetResult()</c>, which can deadlock on hosts with a
+    /// captured synchronization context.
+    /// </remarks>
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        try
+        {
+            await TerminateAsync().ConfigureAwait(false);
+        }
+        catch
+        {
+            // Swallow exceptions during async disposal - matches the sync path.
+        }
+
         GC.SuppressFinalize(this);
     }
 }

--- a/tests/Unit/DotCompute.Core.Tests/Security/MemoryProtectionTests.cs
+++ b/tests/Unit/DotCompute.Core.Tests/Security/MemoryProtectionTests.cs
@@ -713,7 +713,7 @@ public sealed class MemoryProtectionTests : IDisposable
     {
         // Arrange
         var protection = new MemoryProtection(_logger);
-        protection.Dispose();
+        await protection.DisposeAsync();
 
         // Act
         var action = async () => await protection.AllocateProtectedMemoryAsync(1024);

--- a/tests/Unit/DotCompute.Core.Tests/Security/MemorySanitizerTests.cs
+++ b/tests/Unit/DotCompute.Core.Tests/Security/MemorySanitizerTests.cs
@@ -718,7 +718,7 @@ public sealed class MemorySanitizerTests : IDisposable
     {
         // Arrange
         var sanitizer = new MemorySanitizer(_logger);
-        sanitizer.Dispose();
+        await sanitizer.DisposeAsync();
 
         // Act
         var action = async () => await sanitizer.AllocateSanitizedMemoryAsync(1024);
@@ -762,7 +762,7 @@ public sealed class MemorySanitizerTests : IDisposable
     {
         // Arrange
         var sanitizer = new MemorySanitizer(_logger);
-        sanitizer.Dispose();
+        await sanitizer.DisposeAsync();
 
         // Act
         var action = sanitizer.DetectMemoryLeaksAsync;

--- a/tests/Unit/DotCompute.Plugins.Tests/Security/PluginSandboxTests.cs
+++ b/tests/Unit/DotCompute.Plugins.Tests/Security/PluginSandboxTests.cs
@@ -119,7 +119,7 @@ public sealed class PluginSandboxTests : IDisposable
     {
         // Arrange
         _sandbox = new PluginSandbox(_mockLogger);
-        _sandbox.Dispose();
+        await _sandbox.DisposeAsync();
         var permissions = new SandboxPermissions();
 
         // Act
@@ -174,7 +174,7 @@ public sealed class PluginSandboxTests : IDisposable
     {
         // Arrange
         _sandbox = new PluginSandbox(_mockLogger);
-        _sandbox.Dispose();
+        await _sandbox.DisposeAsync();
 
         // Act
         var act = async () => await _sandbox.TerminatePluginAsync(Guid.NewGuid());


### PR DESCRIPTION
## Summary

Upgrades 16 types that manage async resources (background tasks, semaphores, channels, CTS, GPU handles) to implement `IAsyncDisposable` alongside `IDisposable`. Each now has a cooperative async shutdown path that awaits in-flight work instead of blocking on `.GetAwaiter().GetResult()` or `Task.Wait()`.

- **Build:** 0 errors, 0 warnings (`dotnet build DotCompute.sln -c Release`).
- **Tests:** all affected unit suites pass: Core 486/486, Plugins Sandbox 14/14, Core Security 101/101, Abstractions 93/93, CPU 25/25. Two pre-existing flaky failures observed on `main` (`RingKernelWatchdogTests.Dispose_CleansUpResources`, `TimestampInjectorTests.InjectTimestampIntoPtx_InjectedCode_MaintainsValidPtxSyntax`) are unaffected.

## Types upgraded (with heuristic trigger)

| Type | Path | Reason |
|------|------|--------|
| `BackpressureManager` | `src/Extensions/DotCompute.Linq/Reactive/BackpressureManager.cs` | Owns CTS; block-strategy producer park |
| `LogBuffer` | `src/Core/DotCompute.Core/Logging/LogBuffer.cs` | Sync-over-async + background Task + Channel drain |
| `StructuredLogger` | `src/Core/DotCompute.Core/Logging/StructuredLogger.cs` | Sync-over-async on buffer flush |
| `MemorySanitizer` | `src/Core/DotCompute.Core/Security/MemorySanitizer.cs` | Sync-over-async on per-allocation secure wipe |
| `MemoryProtection` | `src/Core/DotCompute.Core/Security/MemoryProtection.cs` | Sync-over-async on per-region secure wipe |
| `CudaPerformanceProfiler` | `src/Backends/DotCompute.Backends.CUDA/Profiling/CudaPerformanceProfiler.cs` | Sync-over-async on `StopProfilingAsync` |
| `CudaPersistentKernelManager` | `src/Backends/DotCompute.Backends.CUDA/Persistent/CudaPersistentKernelManager.cs` | Sync-over-async on `StopKernelAsync` for each active kernel |
| `IPersistentKernelHandle` / `PersistentKernelHandle` | same file | Sync-over-async on `StopAsync`; interface extended |
| `MetalBackend` | `src/Backends/DotCompute.Backends.Metal/MetalBackend.cs` | `AsTask().GetAwaiter().GetResult()` on each accelerator |
| `RuntimeExecutor` | `src/Extensions/DotCompute.Linq/CodeGeneration/RuntimeExecutor.cs` | `AsTask().Wait()` on accelerator dispose |
| `CudaRuntimeKernelCompiler` | `src/Extensions/DotCompute.Linq/Compilation/CudaRuntimeKernelCompiler.cs` | `SemaphoreSlim.Wait()` in sync Dispose |
| `MetalRuntimeKernelCompiler` | `src/Extensions/DotCompute.Linq/Compilation/MetalRuntimeKernelCompiler.cs` | `SemaphoreSlim.Wait()` in sync Dispose |
| `CompilationPipeline` | `src/Extensions/DotCompute.Linq/CodeGeneration/CompilationPipeline.cs` | Owns both async-disposable GPU compilers |
| `NuGetPluginManager` | `src/Runtime/DotCompute.Plugins/Managers/NuGetPluginManager.cs` | Sync-over-async on `UnloadPluginAsync` |
| `SandboxedPlugin` | `src/Runtime/DotCompute.Plugins/Security/SandboxedPlugin.cs` | Sync-over-async on `TerminateAsync` |
| `PluginSandbox` | `src/Runtime/DotCompute.Plugins/Security/PluginSandbox.cs` | Sync-over-async across all sandboxed plugins |
| `KernelSandbox` | `src/Extensions/DotCompute.Algorithms/Security/KernelSandbox.cs` | `Task.WaitAll(30s)` on sandbox destruction tasks |

### Deliberately skipped

- `PipelineTelemetryCollector`, `NumaScheduler`, `MetalGraphExecutor`, `MetalEventManager`, `CudaEventManager`, `MultiGpuSynchronizer`, `ParallelOptimizations.WorkStealingPool`, `PluginLifecycleManager`, `AlgorithmPluginLifecycle` — sync-only `Dispose` (CTS cancel + timer dispose, `Thread.Join`, or trivial handle release). No awaitable in-flight work to drain; over-async would be churn.
- `CudaMemoryManager`, `MetalMemoryManager` — already implement `IAsyncDisposable` via `BaseMemoryManager`.
- `CudaRingKernelRuntime` — already implements `IAsyncDisposable` via `IRingKernelRuntime`.

### Call-site migrations

4 test methods that called sync `Dispose()` inside `async Task` methods were upgraded to `await ...DisposeAsync()`:

- `tests/Unit/DotCompute.Core.Tests/Security/MemorySanitizerTests.cs` — 2 cases
- `tests/Unit/DotCompute.Core.Tests/Security/MemoryProtectionTests.cs` — 1 case
- `tests/Unit/DotCompute.Plugins.Tests/Security/PluginSandboxTests.cs` — 2 cases

Production call sites were left as-is: the build-time CA1849/VSTHRD103 analyzers would have flagged any regression (and the build is warning-clean).

## Pattern applied

Each upgraded class keeps both sync and async paths idempotent and shares cleanup where reasonable:

```csharp
public async ValueTask DisposeAsync()
{
    if (_disposed) return;
    _disposed = true;

    // Cancel CTS cooperatively, await background tasks,
    // drain channels, await per-resource AsyncDispose.
    await BackgroundWorkAsync().ConfigureAwait(false);

    // Then release sync-only handles.
    _timer?.Dispose();
    _semaphore?.Dispose();
    _cts.Dispose();

    GC.SuppressFinalize(this);
}
```

No new interfaces were introduced — all additions go through `System.IAsyncDisposable`.

## Test plan

- [x] `dotnet build DotCompute.sln -c Release` → 0 errors, 0 warnings
- [x] `dotnet test` on `DotCompute.Core.Tests` (486/486), `DotCompute.Backends.CPU.Tests` (25/25), `DotCompute.Abstractions.Tests` (93/93), `DotCompute.Plugins.Tests` filter `PluginSandboxTests` (14/14), `DotCompute.Core.Tests` filter `Memory{Sanitizer,Protection}Tests` (101/101)
- [x] Parity check against `main` — no new test failures introduced by this PR
- [ ] Hardware tests (CUDA) — reviewer to run on CUDA-enabled CI; unaffected by this PR since no kernel semantics changed
- [ ] Downstream consumers (Orleans.GpuBridge.Core) — review whether any `using` blocks on these types should migrate to `await using`

🤖 Generated with [Claude Code](https://claude.com/claude-code)