### PR TITLE
refactor: replace reflection with UnsafeAccessor in hot paths

### DIFF
--- a/src/Backends/DotCompute.Backends.CPU/CpuMemoryManager.cs
+++ b/src/Backends/DotCompute.Backends.CPU/CpuMemoryManager.cs
@@ -1236,13 +1236,20 @@ internal sealed class CpuMemoryBufferTypedWrapper<T> : IUnifiedMemoryBuffer<T> w
     public ValueTask DisposeAsync() => _view.DisposeAsync();
 
     // Helper methods
-    private CpuMemoryBuffer GetParentBuffer()
-    {
-        // Access the parent buffer from the view
-        // This uses reflection to access the private field, which is not ideal
-        // but necessary for the current implementation
-        var field = typeof(CpuMemoryBufferView).GetField("_parent",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        return (CpuMemoryBuffer)(field?.GetValue(_view) ?? throw new InvalidOperationException("Could not access parent buffer"));
-    }
+    private CpuMemoryBuffer GetParentBuffer() => CpuMemoryBufferViewAccessor.GetParent(_view);
+}
+
+/// <summary>
+/// AOT-friendly accessor for the private <c>_parent</c> field on
+/// <see cref="CpuMemoryBufferView"/>. Replaces runtime <c>FieldInfo.GetValue</c>
+/// reflection with a source-gen-resolved extern shim that the JIT inlines into a
+/// direct field load — same speed as a normal field access, no trim/AOT warnings.
+/// </summary>
+internal static class CpuMemoryBufferViewAccessor
+{
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_parent")]
+    private static extern ref CpuMemoryBuffer ParentRef(CpuMemoryBufferView view);
+
+    public static CpuMemoryBuffer GetParent(CpuMemoryBufferView view)
+        => ParentRef(view) ?? throw new InvalidOperationException("Could not access parent buffer");
 }

--- a/src/Backends/DotCompute.Backends.Metal/Execution/MetalCommandExecutor.cs
+++ b/src/Backends/DotCompute.Backends.Metal/Execution/MetalCommandExecutor.cs
@@ -90,23 +90,21 @@ public sealed class MetalCommandExecutor : IMetalCommandExecutor
 
         ArgumentNullException.ThrowIfNull(kernel);
 
-        // Extract pipeline state from kernel using reflection (MetalCompiledKernel has private _pipelineState field)
-        var kernelType = kernel.GetType();
-#pragma warning disable IL2075 // Reflection on kernel type is safe - Metal backend controls kernel types
-        var pipelineStateField = kernelType.GetField("_pipelineState",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-#pragma warning restore IL2075
+        // Production path: statically-typed access via UnsafeAccessor (AOT-safe, no reflection).
+        // Test path: anything that isn't a MetalCompiledKernel (e.g. mock) silently no-ops, matching
+        // the previous reflection-based behavior.
+        if (kernel is MetalCompiledKernel compiledKernel)
+        {
+            var pipelineState = MetalCompiledKernelAccessor.PipelineState(compiledKernel);
+            if (pipelineState != IntPtr.Zero)
+            {
+                MetalNative.SetComputePipelineState(encoder, pipelineState);
+                _logger.LogTrace("Set pipeline state {Pipeline} on encoder {Encoder}", pipelineState, encoder);
+                return;
+            }
+        }
 
-        if (pipelineStateField != null && pipelineStateField.GetValue(kernel) is IntPtr pipelineState && pipelineState != IntPtr.Zero)
-        {
-            MetalNative.SetComputePipelineState(encoder, pipelineState);
-            _logger.LogTrace("Set pipeline state {Pipeline} on encoder {Encoder}", pipelineState, encoder);
-        }
-        else
-        {
-            // This might be a test scenario with a mock kernel
-            _logger.LogTrace("Skipping pipeline state for kernel type: {KernelType}", kernelType.Name);
-        }
+        _logger.LogTrace("Skipping pipeline state for kernel type: {KernelType}", kernel.GetType().Name);
     }
 
     /// <inheritdoc/>

--- a/src/Backends/DotCompute.Backends.Metal/Execution/MetalExecutionEngine.cs
+++ b/src/Backends/DotCompute.Backends.Metal/Execution/MetalExecutionEngine.cs
@@ -257,39 +257,18 @@ public sealed class MetalExecutionEngine : IDisposable
     }
 
     /// <summary>
-    /// Extracts the pipeline state handle from a compiled Metal kernel using reflection.
+    /// Extracts the pipeline state handle from a compiled Metal kernel.
     /// </summary>
     /// <param name="kernel">The compiled kernel.</param>
     /// <returns>The pipeline state handle.</returns>
-    /// <exception cref="InvalidOperationException">Thrown when pipeline state cannot be extracted.</exception>
     /// <remarks>
-    /// This method uses reflection to access the private _pipelineState field.
-    /// This is necessary because MetalCompiledKernel doesn't expose the pipeline state publicly.
+    /// Delegates to <see cref="MetalCompiledKernelAccessor"/>, which uses
+    /// <c>UnsafeAccessor</c> to access the private <c>_pipelineState</c> field on
+    /// <see cref="MetalCompiledKernel"/>. The accessor is resolved at source-gen time
+    /// (AOT-safe, no trim warnings) and inlined into a direct field load by the JIT.
     /// </remarks>
     private static IntPtr GetPipelineStateFromKernel(MetalCompiledKernel kernel)
-    {
-        var kernelType = typeof(MetalCompiledKernel);
-
-#pragma warning disable IL2075 // Reflection on kernel type is safe - Metal backend controls kernel types
-        var pipelineStateField = kernelType.GetField("_pipelineState",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-#pragma warning restore IL2075
-
-        if (pipelineStateField == null)
-        {
-            throw new InvalidOperationException(
-                "Unable to access pipeline state from MetalCompiledKernel. Internal structure may have changed.");
-        }
-
-        var pipelineStateValue = pipelineStateField.GetValue(kernel);
-        if (pipelineStateValue is IntPtr pipelineState)
-        {
-            return pipelineState;
-        }
-
-        throw new InvalidOperationException(
-            "Pipeline state field exists but has unexpected type or null value.");
-    }
+        => MetalCompiledKernelAccessor.PipelineState(kernel);
 
     /// <summary>
     /// Disposes the execution engine and releases native resources.

--- a/src/Backends/DotCompute.Backends.Metal/Kernels/MetalCompiledKernelAccessor.cs
+++ b/src/Backends/DotCompute.Backends.Metal/Kernels/MetalCompiledKernelAccessor.cs
@@ -1,0 +1,34 @@
+// Copyright (c) 2025 Michael Ivertowski
+// Licensed under the MIT License. See LICENSE file in the project root for license information.
+
+using System.Runtime.CompilerServices;
+
+namespace DotCompute.Backends.Metal.Kernels;
+
+/// <summary>
+/// AOT-friendly accessor for the private <c>_pipelineState</c> field on
+/// <see cref="MetalCompiledKernel"/>.
+///
+/// <para>
+/// The execution layer needs the raw <c>MTLComputePipelineState</c> handle to bind
+/// to a command encoder, but <see cref="MetalCompiledKernel"/> deliberately keeps the
+/// native handle private. Using <see cref="UnsafeAccessorAttribute"/> instead of
+/// <c>FieldInfo.GetValue</c> resolves the field at source-gen time, removes the
+/// runtime reflection call (and its associated trim/AOT warnings), and lets the JIT
+/// inline the access into a single field load.
+/// </para>
+/// </summary>
+internal static class MetalCompiledKernelAccessor
+{
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_pipelineState")]
+    private static extern ref IntPtr PipelineStateRef(MetalCompiledKernel kernel);
+
+    /// <summary>
+    /// Returns the native <c>MTLComputePipelineState</c> handle for the given compiled kernel.
+    /// </summary>
+    public static IntPtr PipelineState(MetalCompiledKernel kernel)
+    {
+        ArgumentNullException.ThrowIfNull(kernel);
+        return PipelineStateRef(kernel);
+    }
+}

--- a/src/Core/DotCompute.Memory/UnifiedBufferMemory.cs
+++ b/src/Core/DotCompute.Memory/UnifiedBufferMemory.cs
@@ -215,18 +215,11 @@ public sealed partial class UnifiedBuffer<T>
             // Update length and recalculate size
             var newSizeInBytes = newLength * Unsafe.SizeOf<T>();
 
-            // Use reflection to update readonly properties
-
-            var lengthField = typeof(UnifiedBuffer<T>).GetField("<Length>k__BackingField",
-
-                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            lengthField?.SetValue(this, newLength);
-
-
-            var sizeField = typeof(UnifiedBuffer<T>).GetField("<SizeInBytes>k__BackingField",
-
-                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            sizeField?.SetValue(this, newSizeInBytes);
+            // AOT-friendly: mutate the auto-property backing fields via UnsafeAccessor.
+            // Replaces FieldInfo.SetValue reflection with a source-gen-resolved extern shim
+            // that the JIT inlines into a direct field store.
+            UnifiedBufferBackingFields.LengthRef(this) = newLength;
+            UnifiedBufferBackingFields.SizeInBytesRef(this) = newSizeInBytes;
 
             // Reallocate host memory
             _hostArray = new T[newLength];
@@ -301,6 +294,27 @@ public sealed partial class UnifiedBuffer<T>
             _ = _asyncLock.Release();
         }
     }
+}
+
+/// <summary>
+/// AOT-friendly accessors for the auto-property backing fields of <see cref="UnifiedBuffer{T}"/>.
+/// Used by <see cref="UnifiedBuffer{T}.Resize(int)"/> to mutate the otherwise-readonly
+/// <c>Length</c> and <c>SizeInBytes</c> properties without runtime reflection.
+///
+/// <para>
+/// <see cref="UnsafeAccessorAttribute"/> resolves the field reference at source-gen time,
+/// and the JIT inlines the accessor into a direct field store. This removes two
+/// <c>FieldInfo.SetValue</c> calls from the Resize hot path and makes the code
+/// trim/AOT-safe.
+/// </para>
+/// </summary>
+internal static class UnifiedBufferBackingFields
+{
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "<Length>k__BackingField")]
+    public static extern ref int LengthRef<T>(UnifiedBuffer<T> buffer) where T : unmanaged;
+
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "<SizeInBytes>k__BackingField")]
+    public static extern ref long SizeInBytesRef<T>(UnifiedBuffer<T> buffer) where T : unmanaged;
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

- Swap three same-assembly `FieldInfo.GetValue`/`SetValue` sites for `[UnsafeAccessor]`-based extern shims (4 call sites, 3 distinct accessors). Each shim is resolved by the JIT at source-gen time and inlined into a direct field load/store — same hot-path cost as a normal field access, with no trim/AOT warnings and no reflection stack frame.
- Investigated the full surface of `src/` reflection; most remaining sites target runtime-loaded plugins, generic-typed consumer attributes, or open generics where `T` isn't known at the call site, and are correctly out of scope (see "Rejected candidates" below).

## Adoption sites

### 1. `CpuMemoryBufferView._parent` — `src/Backends/DotCompute.Backends.CPU/CpuMemoryManager.cs`
`CpuMemoryBufferTypedWrapper<T>.GetParentBuffer()` previously reflected into the view's internal `_parent` reference on every call. The comment in the old code explicitly noted *"uses reflection to access the private field, which is not ideal."* Now delegates to a new `CpuMemoryBufferViewAccessor` helper that uses `[UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_parent")]`.

### 2. `UnifiedBuffer<T>.Length` / `SizeInBytes` backing fields — `src/Core/DotCompute.Memory/UnifiedBufferMemory.cs`
`Resize(int)` previously used two `FieldInfo.SetValue` calls against the compiler-generated `<Length>k__BackingField` and `<SizeInBytes>k__BackingField` names to mutate the otherwise-readonly auto-properties. Now delegates to a new `UnifiedBufferBackingFields` helper with generic `UnsafeAccessor` methods — leverages the .NET 9+ generic-parameter support.

### 3. `MetalCompiledKernel._pipelineState` — 2 call sites in `src/Backends/DotCompute.Backends.Metal/Execution/`
`MetalExecutionEngine.GetPipelineStateFromKernel` and `MetalCommandExecutor.SetComputePipelineState` previously reflected to extract the native `MTLComputePipelineState` handle on every kernel dispatch. Both now share a single new `MetalCompiledKernelAccessor.PipelineState()` helper. The command executor also pattern-matches on `MetalCompiledKernel` directly instead of walking `kernel.GetType()`, so mock kernels in tests still no-op cleanly via the fallback branch.

## Rejected candidates (investigated, not viable)

| Site | Why skipped |
|---|---|
| `TypedMemoryBufferWrapper<T>._underlyingBuffer` (Metal `ExtractMetalBuffer`/`UnwrapBuffer`) | Concrete `T` unknown at the call site — needed a non-generic marker interface or InternalsVisibleTo + public accessor, out of scope |
| `GeneratedKernelDiscoveryService` (`Name`, `FullName`, `Backends`, `VectorSize`, `IsParallel` on `KernelAttribute`) | `KernelAttribute` comes from arbitrary consumer assemblies; runtime (`DotCompute.Runtime`) doesn't reference `DotCompute.Generators.Attributes` |
| `AotPluginRegistry` / `PluginSystem.CreatePluginInstance` | Reflects on runtime-loaded plugin `Type`s — not statically resolvable |
| `CudaKernelLauncher` `_devicePtr`/`DevicePointer` lookups | Runtime-generated generic types (`CudaMemoryBuffer<T>` with unknown T) |
| `CPU/Metal/CUDA RingKernelRuntime` queue reflection (`TryDequeue`/`TryEnqueue`/`Count`/`Capacity`) | Reflects on `InputQueue`/`OutputQueue` typed as `object?`; concrete queue types only known at dispatch time |
| `IAcceleratorExtensions` / `ICompiledKernelExtensions` | Reflect on arbitrary `IAccelerator` / `ICompiledKernel` implementations by name; targets are interface-style members |
| `SystemInfoManager` WMI paths (per task note) | WMI types loaded dynamically, as expected |
| `ComputeQueryableExtensions.ExecuteTyped<T>` via `MakeGenericMethod` | Runtime-only element type |
| `MetalAccelerator.PerformCleanup` reflecting `BaseAccelerator._logger` | Not an UnsafeAccessor case — `BaseAccelerator` already exposes `protected ILogger Logger`; this is a gratuitous-reflection bug for a separate cleanup PR |

## Build / test status

- `dotnet build DotCompute.sln --configuration Release` → **0 errors, 0 warnings**
- `DotCompute.Backends.CPU.Tests` → 140/140 pass
- `DotCompute.Core.Tests` → 1692/1700 pass (6 flaky failures — main baseline shows 9 failures for the same suite; same 2 skips)
- `DotCompute.Memory.Tests` `Resize` filter → 13/13 pass (directly exercises the `UnsafeAccessor` rewrite of `Length`/`SizeInBytes` backing fields)
- `DotCompute.Memory.Tests` full suite → 48 failures, identical set to main baseline (pre-existing FluentAssertions / buffer-tracking test flakes; not introduced by this PR)

## Test plan

- [x] Full solution build 0/0
- [x] Targeted Resize tests pass (validates the one site that writes readonly auto-property backing fields)
- [x] CPU backend tests 140/140 pass (validates `CpuMemoryBufferViewAccessor`)
- [x] Core tests no new regressions vs main
- [ ] Metal on-device tests (not runnable on Linux CI; Metal changes compile cleanly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)