### PR TITLE
fix(deps): bump OpenTelemetry to 1.15.3 to clear build-breaking CVEs

### DIFF
--- a/src/Core/DotCompute.Core/DotCompute.Core.csproj
+++ b/src/Core/DotCompute.Core/DotCompute.Core.csproj
@@ -51,10 +51,10 @@
     
     <!-- Telemetry and Observability -->
     <!-- System.Diagnostics.Metrics is included in .NET 9.0 runtime -->
-    <PackageReference Include="OpenTelemetry" Version="1.15.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.9.0-beta.2" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageReference Include="prometheus-net" Version="8.2.1" />
     
     <!-- High-performance collections and threading -->


### PR DESCRIPTION
## Problem

`main` does not build. `OpenTelemetry` 1.15.0 and `OpenTelemetry.Exporter.OpenTelemetryProtocol` 1.15.0 now carry known moderate-severity advisories:

- [GHSA-g94r-2vxg-569j](https://github.com/advisories/GHSA-g94r-2vxg-569j) (`OpenTelemetry.Api`)
- [GHSA-4625-4j76-fww9](https://github.com/advisories/GHSA-4625-4j76-fww9), [GHSA-mr8r-92fq-pj8p](https://github.com/advisories/GHSA-mr8r-92fq-pj8p), [GHSA-q834-8qmm-v933](https://github.com/advisories/GHSA-q834-8qmm-v933) (`OpenTelemetry.Exporter.OpenTelemetryProtocol`)

With `TreatWarningsAsErrors=true` and NuGet audit enabled, these become **48 `NU1902` build errors** across the solution. This is also why the open Dependabot PRs show red CI — their bases carry the same vulnerable packages.

## Fix

Bump the OTel family from `1.15.0` → `1.15.3` in `src/Core/DotCompute.Core/DotCompute.Core.csproj` (the only file referencing these packages directly):

- `OpenTelemetry`
- `OpenTelemetry.Extensions.Hosting` (kept version-aligned)
- `OpenTelemetry.Exporter.OpenTelemetryProtocol`

`OpenTelemetry.Exporter.Prometheus.AspNetCore` (1.9.0-beta.2) is on a separate release track and is not affected.

## Verification

- `dotnet build DotCompute.sln -c Release` → **0 warnings, 0 errors**
- `dotnet list DotCompute.sln package --vulnerable --include-transitive` → **no vulnerable packages**
- `OpenTelemetry.Api` now resolves transitively to **1.15.3**

Supersedes #157 and #158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)