### PR TITLE
deps: consolidated dependency refresh (microsoft 10.0.9, Polly 8.6.6, NuGet 7.6.0)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,9 +7,9 @@
   <ItemGroup>
     <!-- Test Framework Package Versions -->
     <PackageVersion Include="Castle.Core" Version="5.2.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageVersion Include="System.Formats.Asn1" Version="10.0.6" />
     <PackageVersion Include="System.IO.Pipelines" Version="10.0.6" />
@@ -30,19 +30,19 @@
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <!-- Microsoft Extensions Package Versions -->
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     <!-- Roslyn Analyzer Testing Package Versions -->
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzer.Testing" Version="1.1.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9" />
     <!-- System Package Versions -->
     <PackageVersion Include="System.Management" Version="10.0.6" />
     <PackageVersion Include="System.Collections.Immutable" Version="10.0.6" />
@@ -66,6 +66,6 @@
     <!-- Source Link -->
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.202" />
     <!-- ILLink Tasks -->
-    <PackageVersion Include="Microsoft.NET.ILLink.Tasks" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.NET.ILLink.Tasks" Version="10.0.9" />
   </ItemGroup>
 </Project>

--- a/src/Backends/DotCompute.Backends.CPU/DotCompute.Backends.CPU.csproj
+++ b/src/Backends/DotCompute.Backends.CPU/DotCompute.Backends.CPU.csproj
@@ -69,14 +69,14 @@
 
   <ItemGroup>
     <!-- CPU-specific dependencies -->
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
     <PackageReference Include="System.Management" Version="10.0.6" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="10.0.6" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
-    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.6" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.9" />
     <PackageReference Include="XmlFix.Analyzers" Version="0.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Backends/DotCompute.Backends.CUDA/DotCompute.Backends.CUDA.csproj
+++ b/src/Backends/DotCompute.Backends.CUDA/DotCompute.Backends.CUDA.csproj
@@ -64,12 +64,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.6" />
-    <PackageReference Include="Polly" Version="8.6.5" />
-    <PackageReference Include="Polly.Extensions" Version="8.6.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.9" />
+    <PackageReference Include="Polly" Version="8.6.6" />
+    <PackageReference Include="Polly.Extensions" Version="8.6.6" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
     <PackageReference Include="XmlFix.Analyzers" Version="0.1.0">
       <PrivateAssets>all</PrivateAssets>
@@ -79,8 +79,8 @@
 
   <!-- Copy native CUDA wrapper to output -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
     <Content Include="runtimes\**\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <PackagePath>runtimes\</PackagePath>

--- a/src/Backends/DotCompute.Backends.Metal/DotCompute.Backends.Metal.csproj
+++ b/src/Backends/DotCompute.Backends.Metal/DotCompute.Backends.Metal.csproj
@@ -57,13 +57,13 @@
 
   <ItemGroup>
     <!-- Metal-specific dependencies -->
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.9" />
   </ItemGroup>
 
   <!-- Native Metal library references -->

--- a/src/Core/DotCompute.Abstractions/DotCompute.Abstractions.csproj
+++ b/src/Core/DotCompute.Abstractions/DotCompute.Abstractions.csproj
@@ -41,10 +41,10 @@
 
   <ItemGroup>
     <!-- AOT-friendly dependencies only -->
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
     <!-- High-performance serialization (AOT-compatible source generator) -->
     <PackageReference Include="MemoryPack" Version="1.21.4" />
   </ItemGroup>
@@ -52,8 +52,8 @@
   <ItemGroup><!-- Analyzers for AOT compatibility -->
   
   
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.202" />
-  <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.6" />
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.301" />
+  <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Core/DotCompute.Core/DotCompute.Core.csproj
+++ b/src/Core/DotCompute.Core/DotCompute.Core.csproj
@@ -45,9 +45,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
     
     <!-- Telemetry and Observability -->
     <!-- System.Diagnostics.Metrics is included in .NET 9.0 runtime -->
@@ -95,14 +95,14 @@
 
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.202" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.6" />
-  <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.6" />
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.301" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+  <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.9" />
   </ItemGroup>
 
 </Project>

--- a/src/Core/DotCompute.Memory/DotCompute.Memory.csproj
+++ b/src/Core/DotCompute.Memory/DotCompute.Memory.csproj
@@ -43,11 +43,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.202" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.6" />
-  <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.6" />
-  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.6" />
-    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.6" />
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.301" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+  <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.9" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -90,7 +90,7 @@
 
   <!-- Analyzers -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.202">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.301">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Extensions/DotCompute.Algorithms/DotCompute.Algorithms.csproj
+++ b/src/Extensions/DotCompute.Algorithms/DotCompute.Algorithms.csproj
@@ -27,22 +27,22 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.6" />
-    <PackageReference Include="NuGet.Common" Version="7.3.1" />
-    <PackageReference Include="NuGet.Configuration" Version="7.3.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
+    <PackageReference Include="NuGet.Common" Version="7.6.0" />
+    <PackageReference Include="NuGet.Configuration" Version="7.6.0" />
     <PackageReference Include="NuGet.DependencyResolver.Core" Version="7.3.1" />
-    <PackageReference Include="NuGet.Frameworks" Version="7.3.1" />
+    <PackageReference Include="NuGet.Frameworks" Version="7.6.0" />
     <PackageReference Include="NuGet.PackageManagement" Version="7.3.1" />
-    <PackageReference Include="NuGet.Packaging" Version="7.3.1" />
-    <PackageReference Include="NuGet.Protocol" Version="7.3.1" />
-    <PackageReference Include="NuGet.Resolver" Version="7.3.1" />
-    <PackageReference Include="NuGet.Versioning" Version="7.3.1" />
-    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.6" />
-    <PackageReference Include="Polly" Version="8.6.5" />
+    <PackageReference Include="NuGet.Packaging" Version="7.6.0" />
+    <PackageReference Include="NuGet.Protocol" Version="7.6.0" />
+    <PackageReference Include="NuGet.Resolver" Version="7.6.0" />
+    <PackageReference Include="NuGet.Versioning" Version="7.6.0" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.9" />
+    <PackageReference Include="Polly" Version="8.6.6" />
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="10.0.6" />
     <PackageReference Include="XmlFix.Analyzers" Version="0.1.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Extensions/DotCompute.Linq/DotCompute.Linq.csproj
+++ b/src/Extensions/DotCompute.Linq/DotCompute.Linq.csproj
@@ -32,10 +32,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.6" />
-    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.9" />
     <PackageReference Include="System.Reactive" Version="6.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
   </ItemGroup>

--- a/src/Runtime/DotCompute.Generators/DotCompute.Generators.csproj
+++ b/src/Runtime/DotCompute.Generators/DotCompute.Generators.csproj
@@ -94,7 +94,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.202" PrivateAssets="all" />
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.301" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/src/Runtime/DotCompute.Plugins/DotCompute.Plugins.csproj
+++ b/src/Runtime/DotCompute.Plugins/DotCompute.Plugins.csproj
@@ -27,24 +27,24 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="10.0.6" />
     <PackageReference Include="System.Composition" Version="10.0.6" />
     <PackageReference Include="McMaster.NETCore.Plugins" Version="2.0.0" />
     <!-- NuGet and Security Dependencies -->
-    <PackageReference Include="NuGet.Common" Version="7.3.1" />
-    <PackageReference Include="NuGet.Configuration" Version="7.3.1" />
-    <PackageReference Include="NuGet.Frameworks" Version="7.3.1" />
-    <PackageReference Include="NuGet.Packaging" Version="7.3.1" />
-    <PackageReference Include="NuGet.Protocol" Version="7.3.1" />
-    <PackageReference Include="NuGet.Resolver" Version="7.3.1" />
-    <PackageReference Include="NuGet.Versioning" Version="7.3.1" />
+    <PackageReference Include="NuGet.Common" Version="7.6.0" />
+    <PackageReference Include="NuGet.Configuration" Version="7.6.0" />
+    <PackageReference Include="NuGet.Frameworks" Version="7.6.0" />
+    <PackageReference Include="NuGet.Packaging" Version="7.6.0" />
+    <PackageReference Include="NuGet.Protocol" Version="7.6.0" />
+    <PackageReference Include="NuGet.Resolver" Version="7.6.0" />
+    <PackageReference Include="NuGet.Versioning" Version="7.6.0" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="10.0.6" />
     <PackageReference Include="XmlFix.Analyzers" Version="0.1.0">
       <PrivateAssets>all</PrivateAssets>
@@ -57,10 +57,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.202" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.6" />
-  <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.6" />
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.301" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+  <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.9" />
   </ItemGroup>
 
 </Project>

--- a/src/Runtime/DotCompute.Runtime/DotCompute.Runtime.csproj
+++ b/src/Runtime/DotCompute.Runtime/DotCompute.Runtime.csproj
@@ -48,15 +48,15 @@
 
   <ItemGroup>
     <!-- Runtime dependencies -->
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
     <PackageReference Include="XmlFix.Analyzers" Version="0.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -64,8 +64,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.202" />
-    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.6" />
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.301" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.9" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Consolidates the stalled / overlapping Dependabot **csproj dependency** PRs into one locally-verified change. After the OpenTelemetry fix (#165) landed, Dependabot stopped rebasing several of these onto green `main`, and the microsoft-group PR (#164) was **missing the test Central-Package-Management bump** it needs — raw #164 fails with `NU1109` (downgrade vs the published `DotCompute.Abstractions.V2` transitive requirement of `>= 10.0.9`).

## Changes
- `Microsoft.Extensions.*` `10.0.6 → 10.0.9` across all src projects + `src/Directory.Build.props` **and the test CPM in `Directory.Packages.props`** (the latter fixes the `NU1109` downgrade)
- `Microsoft.NET.ILLink.Tasks` `10.0.6 → 10.0.9`
- `Microsoft.CodeAnalysis.NetAnalyzers` `10.0.202 → 10.0.301`
- `Polly` / `Polly.Extensions` `8.6.5 → 8.6.6`
- `NuGet.{Common,Configuration,Frameworks,Packaging,Protocol,Resolver,Versioning}` `7.3.1 → 7.6.0`
  - `NuGet.PackageManagement` and `NuGet.DependencyResolver.Core` stay at `7.3.1` (no compatible 7.6.0 — this matches the only green Dependabot variant; #151 failed precisely because it bumped `PackageManagement`)

## Supersedes
#164 (microsoft group), #159 + #160 (Polly), #154 + #151 (NuGet group).

## Verification (local)
- `dotnet build DotCompute.sln -c Release` → **0 warnings / 0 errors** (NetAnalyzers 10.0.301 introduced no new diagnostics; no NU1109/NU1605)
- `dotnet list DotCompute.sln package --vulnerable --include-transitive` → clean across all 22 projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)