### PR TITLE
fix(ci): de-flake post-merge gate (watchdog event tests + security set -e)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -63,7 +63,10 @@ jobs:
         # instead: fail only when an actual vulnerable package is reported, and tolerate
         # transient source errors. The build job's NuGet audit (TreatWarningsAsErrors)
         # remains the authoritative hard gate that blocks CVEs at compile time.
-        output=$(dotnet list package --vulnerable --include-transitive 2>&1)
+        # NOTE: `|| true` is required — GitHub runs this with `bash -eo pipefail`, so a
+        # non-zero exit from the transient source error would abort the step before the
+        # grep ever runs, reintroducing the exact flakiness this step is meant to avoid.
+        output=$(dotnet list package --vulnerable --include-transitive 2>&1) || true
         echo "$output"
         if echo "$output" | grep -qi 'has the following vulnerable packages'; then
           echo "::error::Vulnerable NuGet packages detected (see list above)"

--- a/tests/Unit/DotCompute.Backends.CUDA.Tests/RingKernels/Resilience/RingKernelWatchdogTests.cs
+++ b/tests/Unit/DotCompute.Backends.CUDA.Tests/RingKernels/Resilience/RingKernelWatchdogTests.cs
@@ -400,8 +400,15 @@ public sealed class RingKernelWatchdogTests : IAsyncLifetime
             ct => Task.FromResult(false),
             () => new KernelHealthStatus { IsRunning = true });
 
-        // Act - wait for watchdog to detect stall
-        await Task.Delay(200);
+        // Act - poll for the watchdog (50ms interval) to detect the stall. A generous ceiling
+        // instead of a fixed delay so a load-starved CI runner (slow to fire the background
+        // timer, especially under coverage instrumentation) doesn't flake; the loop exits as
+        // soon as the event fires, so the common case stays fast.
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (!faultDetected && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(25);
+        }
 
         // Assert
         Assert.True(faultDetected, "Fault should have been detected");
@@ -452,9 +459,15 @@ public sealed class RingKernelWatchdogTests : IAsyncLifetime
                 return new KernelHealthStatus { IsRunning = crashCounter > 1 };
             });
 
-        // Artificially cause a fault by not reporting activity and having IsRunning=false
-        // Wait for watchdog to detect crash and attempt recovery
-        await Task.Delay(300);
+        // Artificially cause a fault by not reporting activity and having IsRunning=false.
+        // Poll for the watchdog to detect the crash and complete recovery — a generous ceiling
+        // instead of a fixed delay so a load-starved CI runner doesn't flake; the loop exits as
+        // soon as the recovery event fires.
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (!recovered && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(25);
+        }
 
         // Assert
         Assert.True(restartAttempted, "Restart should have been attempted");


### PR DESCRIPTION
Fixes the two nondeterministic failures that surfaced on the post-merge `main` run of #169 (both were green on the PR run of identical content).

## 1. Watchdog event-timing flake

`RingKernelWatchdogTests.KernelFaultDetected_EventFiresOnFault` (+ sibling `KernelRecovered_EventFiresOnSuccessfulRestart`) used a fixed `Task.Delay(200/300ms)` to wait for a 50ms-interval background watchdog timer to fire an event, then asserted the flag. Under CI load + coverlet instrumentation the timer is starved past the fixed window → `Failed: 1, Passed: 648`. Replaced with a poll-until-condition loop (5s ceiling, exits as soon as the event fires); functional assertions kept as hard gates. Verified 3× green locally.

## 2. Security gate `set -e` abort

The `Check for vulnerable packages` step parses `dotnet list package --vulnerable` output to gate only on real CVEs — but assigned it as `output=$(...)` under `bash -eo pipefail`, so a transient non-zero exit (audit-source hiccup) aborted the step *before* the grep. Added `|| true` so the guard runs and only a genuine vulnerable-package match fails. The build job's NuGet audit remains the authoritative compile-time CVE gate.

No product code changed. 0 vulnerable packages solution-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
