### PR TITLE
fix(#182): GPU-init failure no longer crashes runtime + generate CUDA for .Length-bounded kernels

### DIFF
--- a/src/Backends/DotCompute.Backends.CUDA/CudaBackendPlugin.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/CudaBackendPlugin.cs
@@ -52,22 +52,26 @@ namespace DotCompute.Backends.CUDA
             // Register the CUDA backend factory
             services.TryAddSingleton<CudaBackendFactory>();
 
-            // Register multiple CUDA accelerators (one per device)
-            _ = services.AddSingleton(provider =>
-            {
-                var factory = provider.GetRequiredService<CudaBackendFactory>();
-                return factory.CreateAccelerators();
-            });
+            // NOTE: do NOT register `AddSingleton(provider => factory.CreateAccelerators())` — it
+            // returns IEnumerable<IAccelerator> and would hijack GetServices<IAccelerator>(),
+            // shadowing every other backend (see CudaBackendPluginExtensions for the same fix).
 
-            // Register a default CUDA accelerator as the primary CudaAccelerator
-            _ = services.AddSingleton(provider =>
+            // Register a default CUDA accelerator as the primary CudaAccelerator. Must not throw:
+            // if CUDA is unavailable, return null so runtime discovery skips it rather than crashing
+            // the whole process (GH #182).
+            _ = services.AddSingleton<CudaAccelerator>(provider =>
             {
-                var factory = provider.GetRequiredService<CudaBackendFactory>();
-                var defaultAccelerator = factory.CreateDefaultAccelerator();
-
-                return defaultAccelerator == null
-                    ? throw new InvalidOperationException("Failed to create default CUDA accelerator")
-                    : (CudaAccelerator)defaultAccelerator;
+                try
+                {
+                    var factory = provider.GetRequiredService<CudaBackendFactory>();
+                    return (factory.CreateDefaultAccelerator() as CudaAccelerator)!;
+                }
+                catch (Exception ex)
+                {
+                    provider.GetService<ILogger<CudaBackendFactory>>()?.LogWarning(ex,
+                        "CUDA backend unavailable; the default CudaAccelerator was not created.");
+                    return null!;
+                }
             });
         }
 
@@ -318,15 +322,32 @@ namespace DotCompute.Backends.CUDA
             // registration. The default device below provides the CUDA IAccelerator; multi-device
             // enumeration is exposed via CudaBackendFactory for callers that need every device.
 
-            // Register a default CUDA accelerator
-            _ = services.AddSingleton(provider =>
+            // Register a default CUDA accelerator. CRITICAL: never throw from this factory. It is
+            // resolved via GetServices<IAccelerator>() during runtime discovery, which is
+            // all-or-nothing — throwing here (e.g. when CUDA is unavailable on this machine) would
+            // abort discovery of EVERY backend, so even the CPU backend would become unusable
+            // (GH #182). Return null instead so the runtime simply skips CUDA and keeps CPU/others.
+            _ = services.AddSingleton<IAccelerator>(provider =>
             {
-                var factory = provider.GetRequiredService<CudaBackendFactory>();
-                var defaultAccelerator = factory.CreateDefaultAccelerator();
+                try
+                {
+                    var factory = provider.GetRequiredService<CudaBackendFactory>();
+                    var defaultAccelerator = factory.CreateDefaultAccelerator();
+                    if (defaultAccelerator == null)
+                    {
+                        provider.GetService<ILogger<CudaBackendFactory>>()?.LogWarning(
+                            "CUDA backend is not available on this machine; skipping the CUDA accelerator. Other backends (e.g. CPU) remain usable.");
+                        return null!;
+                    }
 
-                return defaultAccelerator == null
-                    ? throw new InvalidOperationException("Failed to create default CUDA accelerator")
-                    : (IAccelerator)new NamedAcceleratorWrapper("cuda", defaultAccelerator);
+                    return new NamedAcceleratorWrapper("cuda", defaultAccelerator);
+                }
+                catch (Exception ex)
+                {
+                    provider.GetService<ILogger<CudaBackendFactory>>()?.LogWarning(ex,
+                        "Failed to initialize the CUDA accelerator; skipping it so other backends (e.g. CPU) remain usable.");
+                    return null!;
+                }
             });
 
             return services;
@@ -341,9 +362,19 @@ namespace DotCompute.Backends.CUDA
 
             _ = services.AddSingleton<IAccelerator>(provider =>
             {
-                var logger = provider.GetService<ILogger<CudaAccelerator>>();
-                var accelerator = new CudaAccelerator(deviceId, logger);
-                return new NamedAcceleratorWrapper($"cuda-{deviceId}", accelerator);
+                try
+                {
+                    var logger = provider.GetService<ILogger<CudaAccelerator>>();
+                    var accelerator = new CudaAccelerator(deviceId, logger);
+                    return new NamedAcceleratorWrapper($"cuda-{deviceId}", accelerator);
+                }
+                catch (Exception ex)
+                {
+                    // Never crash runtime discovery when a device is unavailable (GH #182).
+                    provider.GetService<ILogger<CudaAccelerator>>()?.LogWarning(ex,
+                        "Failed to initialize CUDA device {DeviceId}; skipping it so other backends remain usable.", deviceId);
+                    return null!;
+                }
             });
 
             return services;

--- a/src/Runtime/DotCompute.Generators/Kernel/Generation/KernelExecutionMetadataEmitter.cs
+++ b/src/Runtime/DotCompute.Generators/Kernel/Generation/KernelExecutionMetadataEmitter.cs
@@ -62,17 +62,27 @@ internal static class KernelExecutionMetadataEmitter
     /// Generates the <c>extern "C" __global__</c> CUDA-C source for the kernel, or
     /// <c>(null, null)</c> if the body uses constructs outside the supported subset.
     /// </summary>
-    public static (string? Source, string? EntryPoint) GenerateCuda(KernelMethodInfo method)
+    public static (string? Source, string? EntryPoint, bool NeedsLength) GenerateCuda(KernelMethodInfo method)
     {
         var body = GetBody(method);
         if (body is null)
         {
-            return (null, null);
+            return (null, null, false);
         }
 
         try
         {
+            // A CUDA pointer has no `.Length`. If the body uses a buffer's `.Length` (the common
+            // elementwise `if (i < c.Length)` bound), emit an implicit trailing `__length` kernel
+            // parameter; each `.Length` translates to `__length`, and the runtime supplies the work
+            // size for it (KernelExecutionService, guarded by CudaNeedsLength).
+            var needsLength = UsesBufferLength(body);
+
             var signature = BuildCudaSignature(method);
+            if (needsLength)
+            {
+                signature += ", const unsigned int __length";
+            }
 
             var builder = new StringBuilder();
             _ = builder.Append("extern \"C\" __global__ void ").Append(method.Name).Append('(').Append(signature).Append(") {").Append('\n');
@@ -82,17 +92,23 @@ internal static class KernelExecutionMetadataEmitter
             }
             _ = builder.Append('}');
 
-            return (builder.ToString(), method.Name);
+            return (builder.ToString(), method.Name, needsLength);
         }
 #pragma warning disable CA1031 // Do not catch general exception types - generator must never crash the build
         catch (Exception)
 #pragma warning restore CA1031
         {
-            // Graceful fallback: a kernel that uses unsupported constructs (e.g. span.Length,
-            // Math.* calls) still registers for CPU; it simply has no auto-generated CUDA source.
-            return (null, null);
+            // Graceful fallback: a kernel that uses unsupported constructs (e.g. Math.* calls)
+            // still registers for CPU; it simply has no auto-generated CUDA source.
+            return (null, null, false);
         }
     }
+
+    /// <summary>True if the body reads any <c>&lt;identifier&gt;.Length</c> (treated as a buffer length).</summary>
+    private static bool UsesBufferLength(BlockSyntax body)
+        => body.DescendantNodes()
+               .OfType<MemberAccessExpressionSyntax>()
+               .Any(m => m.Name.Identifier.Text == "Length" && m.Expression is IdentifierNameSyntax);
 
     /// <summary>
     /// Generates the <c>&lt;sanitized&gt;CpuInvoker</c> class that reconstructs typed spans/scalars
@@ -361,6 +377,12 @@ internal static class KernelExecutionMetadataEmitter
 
             case MemberAccessExpressionSyntax memberAccess when TryClassifyIntrinsic(memberAccess, out var intrinsic, out var axis):
                 return $"{intrinsic}.{axis}";
+
+            // A buffer's `.Length` maps to the implicit `__length` kernel parameter (a CUDA pointer
+            // carries no length). GenerateCuda adds `__length` to the signature and flags the
+            // kernel so the runtime supplies the work size for it.
+            case MemberAccessExpressionSyntax lengthAccess when lengthAccess.Name.Identifier.Text == "Length" && lengthAccess.Expression is IdentifierNameSyntax:
+                return "__length";
 
             default:
                 throw new NotSupportedException($"Unsupported expression kind: {expression.Kind()}");

--- a/src/Runtime/DotCompute.Generators/Kernel/Generation/KernelRegistrationEmitter.cs
+++ b/src/Runtime/DotCompute.Generators/Kernel/Generation/KernelRegistrationEmitter.cs
@@ -66,7 +66,7 @@ public sealed class KernelRegistrationEmitter
         {
             var fullName = $"{method.ContainingType}.{method.Name}";
             var dimensions = KernelExecutionMetadataEmitter.DetectDimensions(method);
-            var (cudaSource, cudaEntryPoint) = KernelExecutionMetadataEmitter.GenerateCuda(method);
+            var (cudaSource, cudaEntryPoint, cudaNeedsLength) = KernelExecutionMetadataEmitter.GenerateCuda(method);
             var invokerClassName = KernelExecutionMetadataEmitter.GetInvokerClassName(method);
 
             _ = source.AppendLine($"            {{ \"{fullName}\", new KernelMetadata");
@@ -82,6 +82,7 @@ public sealed class KernelRegistrationEmitter
             _ = source.AppendLine($"                Dimensions = {dimensions},");
             _ = source.AppendLine($"                CudaSource = {FormatCudaSource(cudaSource)},");
             _ = source.AppendLine($"                CudaEntryPoint = {FormatNullableString(cudaEntryPoint)},");
+            _ = source.AppendLine($"                CudaNeedsLength = {Bool(cudaNeedsLength)},");
             _ = source.AppendLine($"                CpuInvoker = (System.Action<object[], int, int>){invokerClassName}.Invoke,");
             _ = source.AppendLine("                Parameters = new KernelParam[]");
             _ = source.AppendLine("                {");
@@ -172,6 +173,7 @@ public sealed class KernelRegistrationEmitter
         _ = source.AppendLine("        public int Dimensions { get; init; }");
         _ = source.AppendLine("        public string? CudaSource { get; init; }");
         _ = source.AppendLine("        public string? CudaEntryPoint { get; init; }");
+        _ = source.AppendLine("        public bool CudaNeedsLength { get; init; }");
         _ = source.AppendLine("        public System.Delegate? CpuInvoker { get; init; }");
         _ = source.AppendLine("        public KernelParam[] Parameters { get; init; } = Array.Empty<KernelParam>();");
         _ = source.AppendLine("    }");

--- a/src/Runtime/DotCompute.Runtime/AcceleratorRuntime.cs
+++ b/src/Runtime/DotCompute.Runtime/AcceleratorRuntime.cs
@@ -75,14 +75,28 @@ public class AcceleratorRuntime(IServiceProvider serviceProvider, ILogger<Accele
         // Primary source: the IAccelerator instances the backends register directly via DI
         // (e.g. AddCpuBackend / AddCudaBackend each register an IAccelerator singleton).
         // This is resolved lazily here — not as a constructor dependency — so GPU accelerators
-        // are only constructed when initialization actually runs.
-        foreach (var accelerator in _serviceProvider.GetServices<IAccelerator>())
+        // are only constructed when initialization actually runs. Backends that cannot initialize
+        // on this machine return null from their factory (see the CUDA backend), which is skipped
+        // here — so a missing GPU never prevents the CPU (or another) backend from being used.
+        //
+        // Defense in depth (GH #182): GetServices<IAccelerator>() is all-or-nothing — if any single
+        // backend factory THROWS during resolution it aborts the whole enumeration, which would
+        // make even a working CPU backend undiscoverable and crash runtime initialization. Guard it
+        // so a misbehaving backend degrades gracefully instead of taking the process down.
+        try
         {
-            if (accelerator is not null && !_accelerators.Contains(accelerator))
+            foreach (var accelerator in _serviceProvider.GetServices<IAccelerator>())
             {
-                _accelerators.Add(accelerator);
-                _logger.LogInfoMessage("Discovered {Type} accelerator: {accelerator.Info.DeviceType, accelerator.Info.Name}");
+                if (accelerator is not null && !_accelerators.Contains(accelerator))
+                {
+                    _accelerators.Add(accelerator);
+                    _logger.LogInfoMessage("Discovered {Type} accelerator: {accelerator.Info.DeviceType, accelerator.Info.Name}");
+                }
             }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "A backend accelerator factory threw while discovering accelerators; some backends may be unavailable. Backends should return null from their IAccelerator factory when they cannot initialize, not throw.");
         }
 
         // Optional fallback: if an IAcceleratorManager is registered, merge any accelerators it

--- a/src/Runtime/DotCompute.Runtime/Services/GeneratedKernelDiscoveryService.cs
+++ b/src/Runtime/DotCompute.Runtime/Services/GeneratedKernelDiscoveryService.cs
@@ -204,6 +204,7 @@ public class GeneratedKernelDiscoveryService(ILogger<GeneratedKernelDiscoverySer
             var dimensions = GetPropertyValue<int>(registration, "Dimensions");
             var cudaSource = GetPropertyValue<string>(registration, "CudaSource");
             var cudaEntryPoint = GetPropertyValue<string>(registration, "CudaEntryPoint");
+            var cudaNeedsLength = GetPropertyValue<bool>(registration, "CudaNeedsLength");
             var cpuInvoker = GetPropertyValue<Delegate>(registration, "CpuInvoker");
             var parameters = ExtractParameters(registration);
 
@@ -228,6 +229,7 @@ public class GeneratedKernelDiscoveryService(ILogger<GeneratedKernelDiscoverySer
                 Dimensions = dimensions > 0 ? dimensions : 1,
                 CudaSource = string.IsNullOrEmpty(cudaSource) ? null : cudaSource,
                 CudaEntryPoint = string.IsNullOrEmpty(cudaEntryPoint) ? null : cudaEntryPoint,
+                CudaNeedsLength = cudaNeedsLength,
                 CpuInvoker = cpuInvoker,
                 Parameters = parameters
             };

--- a/src/Runtime/DotCompute.Runtime/Services/KernelExecutionService.cs
+++ b/src/Runtime/DotCompute.Runtime/Services/KernelExecutionService.cs
@@ -306,6 +306,14 @@ public class KernelExecutionService(
         {
             var (kernelArgs, copyBacks) = await MarshalForDeviceAsync(registration, accelerator, args).ConfigureAwait(false);
 
+            // Supply the implicit `__length` scalar when the generated CUDA kernel needs it (its body
+            // used a buffer's .Length, which a CUDA pointer lacks). Appended after the user scalars so
+            // it lines up with the trailing parameter the generator added to the kernel signature.
+            if (backend == "CUDA" && registration.CudaNeedsLength)
+            {
+                kernelArgs.AddScalar((uint)totalWork);
+            }
+
             kernelArgs.LaunchConfiguration = DeriveLaunch(registration, args, totalWork);
 
             await compiledKernel.ExecuteAsync(kernelArgs);

--- a/src/Runtime/DotCompute.Runtime/Services/KernelExecutionService_Simplified.cs
+++ b/src/Runtime/DotCompute.Runtime/Services/KernelExecutionService_Simplified.cs
@@ -578,6 +578,13 @@ public class KernelRegistrationInfo
     public string? CudaEntryPoint { get; init; }
 
     /// <summary>
+    /// True when <see cref="CudaSource"/> declares a trailing implicit <c>unsigned int __length</c>
+    /// parameter (the kernel body used a buffer's <c>.Length</c>, which a CUDA pointer lacks). When
+    /// set, the runtime appends the work-item count as an extra scalar argument for CUDA launches.
+    /// </summary>
+    public bool CudaNeedsLength { get; init; }
+
+    /// <summary>
     /// Generator-emitted CPU invoker: <c>void (KernelArguments args, int start, int end)</c>. It
     /// unpacks the kernel arguments into typed spans/scalars and runs the kernel body over the
     /// half-open work range [start, end). Null when the kernel does not target CPU. This is the

--- a/tests/Unit/DotCompute.Generators.Tests/Generator/KernelExecutionMetadataTests.cs
+++ b/tests/Unit/DotCompute.Generators.Tests/Generator/KernelExecutionMetadataTests.cs
@@ -56,6 +56,46 @@ public static class KernelContext
 public struct Index3 { public int X => 0; public int Y => 0; public int Z => 0; }
 ";
 
+    // A 1-D elementwise kernel whose bound uses a buffer's .Length (the common VectorAdd shape).
+    // A CUDA pointer has no .Length, so the generator maps it to an implicit __length parameter.
+    private const string VectorAddKernel = @"
+using System;
+namespace TestApp
+{
+    public static class Vec
+    {
+        [Kernel(Backends = KernelBackends.CPU | KernelBackends.CUDA, VectorSize = 8, IsParallel = true)]
+        public static void Add(ReadOnlySpan<float> a, ReadOnlySpan<float> b, Span<float> c)
+        {
+            int i = KernelContext.ThreadId.X;
+            if (i < c.Length)
+                c[i] = a[i] + b[i];
+        }
+    }
+}
+
+[System.AttributeUsage(System.AttributeTargets.Method)]
+public sealed class KernelAttribute : System.Attribute
+{
+    public KernelBackends Backends { get; set; }
+    public int VectorSize { get; set; }
+    public bool IsParallel { get; set; }
+}
+
+[System.Flags]
+public enum KernelBackends { CPU = 1, CUDA = 2, Metal = 4 }
+
+public static class KernelContext
+{
+    public static Index3 ThreadId => default;
+    public static Index3 BlockId => default;
+    public static Index3 BlockDim => default;
+    public static Index3 GridDim => default;
+}
+
+public struct Index3 { public int X => 0; public int Y => 0; public int Z => 0; }
+";
+
     [Fact]
     public void Generator_TransposeNaive_EmitsRealCudaSource()
     {
@@ -124,6 +164,21 @@ public struct Index3 { public int X => 0; public int Y => 0; public int Z => 0; 
     {
         var registry = GetRegistry();
         Assert.Contains("public static IReadOnlyList<KernelMetadata> GetAllKernels()", registry);
+    }
+
+    [Fact]
+    public void Generator_VectorAddUsingSpanLength_EmitsCudaWithImplicitLengthParameter()
+    {
+        // Regression for GH #182 follow-up: a 1-D kernel bounded by a buffer's .Length previously
+        // produced CudaSource = null (a CUDA pointer has no .Length). It must now emit real CUDA-C
+        // with a trailing __length parameter, `.Length` translated to __length, and CudaNeedsLength.
+        var generatedSources = RunGenerator(VectorAddKernel);
+        var registry = generatedSources.FirstOrDefault(s => s.HintName == "KernelRegistry.g.cs").SourceText?.ToString() ?? string.Empty;
+
+        Assert.Contains("__global__ void Add(const float* a, const float* b, float* c, const unsigned int __length)", registry);
+        Assert.Contains("if (i < __length)", registry);
+        Assert.Contains("CudaNeedsLength = true", registry);
+        Assert.DoesNotContain("CudaSource = null", registry); // Add now has real CUDA source
     }
 
     private static string GetRegistry()

--- a/tests/Unit/DotCompute.Runtime.Tests/Initialization/AcceleratorRuntimeTests.cs
+++ b/tests/Unit/DotCompute.Runtime.Tests/Initialization/AcceleratorRuntimeTests.cs
@@ -1,14 +1,9 @@
 // Copyright (c) 2025 Michael Ivertowski
 // Licensed under the MIT License. See LICENSE file in the project root for license information.
 
-// COMMENTED OUT: AcceleratorRuntime constructor signature mismatch and IAccelerator API issues
-// TODO: Uncomment when the following are fixed:
-// - AcceleratorRuntime constructor expects (IServiceProvider, ILogger) not (ILogger, IAccelerator)
-// - IAccelerator.Name property is missing
-/*
 using DotCompute.Abstractions;
-using DotCompute.Runtime.Services;
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Xunit;
@@ -16,181 +11,62 @@ using Xunit;
 namespace DotCompute.Runtime.Tests.Initialization;
 
 /// <summary>
-/// Tests for AcceleratorRuntime
+/// Resilience tests for <see cref="AcceleratorRuntime"/> accelerator discovery.
+/// Regression coverage for GH #182: a backend that cannot initialize on the current machine
+/// (e.g. CUDA on a box with no usable GPU) must NOT prevent the other backends (e.g. CPU) from
+/// being discovered, and must never crash runtime initialization.
 /// </summary>
-public sealed class AcceleratorRuntimeTests : IDisposable
+public sealed class AcceleratorRuntimeTests
 {
-    private readonly ILogger<AcceleratorRuntime> _mockLogger;
-    private readonly IAccelerator _mockAccelerator;
-    private AcceleratorRuntime? _runtime;
+    private static AcceleratorRuntime CreateRuntime(IServiceProvider provider)
+        => new(provider, Substitute.For<ILogger<AcceleratorRuntime>>());
 
-    public AcceleratorRuntimeTests()
+    [Fact]
+    public async Task InitializeAsync_SkipsBackendWhoseFactoryReturnsNull_AndKeepsWorkingAccelerator()
     {
-        _mockLogger = Substitute.For<ILogger<AcceleratorRuntime>>();
-        _mockAccelerator = Substitute.For<IAccelerator>();
-        _mockAccelerator.Name.Returns("TestAccelerator");
-    }
+        // A backend that cannot initialize returns null from its IAccelerator factory (this is how
+        // the CUDA backend now degrades when no usable GPU is present). The working accelerator
+        // (e.g. CPU) must still be discovered.
+        var working = Substitute.For<IAccelerator>();
+        var services = new ServiceCollection();
+        _ = services.AddSingleton<IAccelerator>(_ => null!); // unavailable backend
+        _ = services.AddSingleton(working);                  // working backend
+        using var provider = services.BuildServiceProvider();
+        using var runtime = CreateRuntime(provider);
 
-    public void Dispose()
-    {
-        _runtime?.Dispose();
+        await runtime.InitializeAsync();
+
+        _ = runtime.GetAccelerators().Should().ContainSingle().Which.Should().BeSameAs(working);
     }
 
     [Fact]
-    public void Constructor_WithNullLogger_ThrowsArgumentNullException()
+    public async Task InitializeAsync_DoesNotThrow_WhenABackendFactoryThrows()
     {
-        // Arrange & Act
-        var action = () => new AcceleratorRuntime(null!, _mockAccelerator);
+        // Defense in depth: a backend factory that THROWS during resolution must not crash runtime
+        // initialization. GetServices<IAccelerator>() is all-or-nothing, so an unguarded throw here
+        // would abort discovery of every backend and take the process down (the GH #182 symptom).
+        var services = new ServiceCollection();
+        _ = services.AddSingleton<IAccelerator>(_ => throw new InvalidOperationException("backend init failed"));
+        using var provider = services.BuildServiceProvider();
+        using var runtime = CreateRuntime(provider);
 
-        // Assert
-        action.Should().Throw<ArgumentNullException>()
-            .WithParameterName("logger");
+        var act = async () => await runtime.InitializeAsync();
+
+        _ = await act.Should().NotThrowAsync();
     }
 
     [Fact]
-    public void Constructor_WithNullAccelerator_ThrowsArgumentNullException()
+    public async Task InitializeAsync_IsIdempotent_AndDiscoversRegisteredAccelerators()
     {
-        // Arrange & Act
-        var action = () => new AcceleratorRuntime(_mockLogger, null!);
+        var a = Substitute.For<IAccelerator>();
+        var services = new ServiceCollection();
+        _ = services.AddSingleton(a);
+        using var provider = services.BuildServiceProvider();
+        using var runtime = CreateRuntime(provider);
 
-        // Assert
-        action.Should().Throw<ArgumentNullException>()
-            .WithParameterName("accelerator");
-    }
+        await runtime.InitializeAsync();
+        await runtime.InitializeAsync(); // second call must not double-register
 
-    [Fact]
-    public void Constructor_WithValidParameters_CreatesInstance()
-    {
-        // Arrange & Act
-        _runtime = new AcceleratorRuntime(_mockLogger, _mockAccelerator);
-
-        // Assert
-        _runtime.Should().NotBeNull();
-    }
-
-    [Fact]
-    public void GetAccelerator_ReturnsConfiguredAccelerator()
-    {
-        // Arrange
-        _runtime = new AcceleratorRuntime(_mockLogger, _mockAccelerator);
-
-        // Act
-        var accelerator = _runtime.GetAccelerator();
-
-        // Assert
-        accelerator.Should().BeSameAs(_mockAccelerator);
-    }
-
-    [Fact]
-    public async Task InitializeAsync_Succeeds()
-    {
-        // Arrange
-        _runtime = new AcceleratorRuntime(_mockLogger, _mockAccelerator);
-
-        // Act
-        await _runtime.InitializeAsync();
-
-        // Assert
-        _runtime.IsInitialized.Should().BeTrue();
-    }
-
-    [Fact]
-    public async Task InitializeAsync_CalledTwice_OnlyInitializesOnce()
-    {
-        // Arrange
-        _runtime = new AcceleratorRuntime(_mockLogger, _mockAccelerator);
-
-        // Act
-        await _runtime.InitializeAsync();
-        await _runtime.InitializeAsync();
-
-        // Assert
-        _runtime.IsInitialized.Should().BeTrue();
-    }
-
-    [Fact]
-    public async Task GetAcceleratorInfo_ReturnsInfo()
-    {
-        // Arrange
-        _runtime = new AcceleratorRuntime(_mockLogger, _mockAccelerator);
-        await _runtime.InitializeAsync();
-
-        // Act
-        var info = _runtime.GetAcceleratorInfo();
-
-        // Assert
-        info.Should().NotBeNull();
-        info.Name.Should().Be("TestAccelerator");
-    }
-
-    [Fact]
-    public async Task IsAcceleratorAvailable_AfterInitialization_ReturnsTrue()
-    {
-        // Arrange
-        _runtime = new AcceleratorRuntime(_mockLogger, _mockAccelerator);
-        await _runtime.InitializeAsync();
-
-        // Act
-        var available = _runtime.IsAcceleratorAvailable();
-
-        // Assert
-        available.Should().BeTrue();
-    }
-
-    [Fact]
-    public async Task GetMemoryInfo_ReturnsMemoryInformation()
-    {
-        // Arrange
-        _runtime = new AcceleratorRuntime(_mockLogger, _mockAccelerator);
-        await _runtime.InitializeAsync();
-
-        // Act
-        var memInfo = _runtime.GetMemoryInfo();
-
-        // Assert
-        memInfo.Should().NotBeNull();
-    }
-
-    [Fact]
-    public async Task Dispose_CleansUpResources()
-    {
-        // Arrange
-        _runtime = new AcceleratorRuntime(_mockLogger, _mockAccelerator);
-        await _runtime.InitializeAsync();
-
-        // Act
-        _runtime.Dispose();
-
-        // Assert
-        _mockAccelerator.Received().Dispose();
-    }
-
-    [Fact]
-    public void Dispose_CalledMultipleTimes_DoesNotThrow()
-    {
-        // Arrange
-        _runtime = new AcceleratorRuntime(_mockLogger, _mockAccelerator);
-
-        // Act
-        _runtime.Dispose();
-        _runtime.Dispose();
-
-        // Assert - no exception thrown
-    }
-
-    [Fact]
-    public async Task ExecuteKernelAsync_WithValidKernel_Succeeds()
-    {
-        // Arrange
-        _runtime = new AcceleratorRuntime(_mockLogger, _mockAccelerator);
-        await _runtime.InitializeAsync();
-        var kernel = Substitute.For<IKernel>();
-
-        // Act
-        await _runtime.ExecuteKernelAsync(kernel);
-
-        // Assert
-        await _mockAccelerator.Received().ExecuteAsync(kernel);
+        _ = runtime.GetAccelerators().Should().ContainSingle().Which.Should().BeSameAs(a);
     }
 }
-*/


### PR DESCRIPTION
Follow-up to #183 (which merged the initial `[Kernel]` → orchestrator fix). The reporter (@Ady-izs) tested the merged fix and it **still crashed at runtime** — and separately noted their `Add` kernel produced no CUDA source. This PR fixes both, reproduced and verified on hardware.

## 1. A failing GPU backend no longer crashes the whole runtime (the reporter's crash)

Their exact error:
```
System.InvalidOperationException: Failed to create default CUDA accelerator
   at CudaBackendPluginExtensions.<AddCudaBackend>b__0_0(IServiceProvider)
   ... at AcceleratorRuntime.DiscoverAcceleratorsAsync()   // GetServices<IAccelerator>()
   ... at KernelExecutionService.GetSupportedAcceleratorsAsync(...)
```

**Root cause:** on a machine where CUDA can't initialize (their Windows + GTX 1650), `CudaBackendFactory.CreateDefaultAccelerator()` returns null and the CUDA DI factory *threw*. `AcceleratorRuntime.DiscoverAcceleratorsAsync()` resolves accelerators via `GetServices<IAccelerator>()`, which is **all-or-nothing** — one backend's factory throwing aborts discovery of *every* backend, so even the CPU backend they wanted became unusable and runtime init crashed. (Ironically #183's own lazy-init wiring is what first invoked the CUDA factory and surfaced this.)

**Reproduced** locally and on the A10 with `CUDA_VISIBLE_DEVICES=""`, then fixed:
- The CUDA `IAccelerator` factories (default + deviceId + the plugin path) now **return null when CUDA is unavailable** instead of throwing (logging a warning). A null is skipped by discovery, so a missing/broken GPU degrades to CPU.
- **Defense in depth:** `DiscoverAcceleratorsAsync` guards the `GetServices` enumeration so any backend factory that still throws can't take the process down.
- Removed the plugin path's leftover `IEnumerable<IAccelerator>` shadowing registration.
- Regression tests (DI-based) replacing the stale commented-out ones.

## 2. Generate CUDA for kernels bounded by a buffer's `.Length` (their `Add`/VectorAdd)

Their `Add` kernel uses `if (i < c.Length)`. A CUDA pointer has no `.Length`, so the translator gave up (`CudaSource = null`; CPU still worked). Now `.Length` maps to an implicit trailing `const unsigned int __length` parameter, the registry flags `CudaNeedsLength`, and the runtime supplies the work-item count as an extra scalar for CUDA launches (the CPU invoker keeps the real span `.Length`).

## Verified on an A10 (both fixes)

The reporter's **exact global-namespace kernels**, no manual registration:
```
CUDA UNAVAILABLE:  GetSupportedAcceleratorsAsync("Add") = 1 (no crash)
                   Add CPU -> 11,22,33,44 ✓   TransposeNaive CPU -> correct ✓
CUDA AVAILABLE:    Add CPU/CUDA -> 11,22,33,44 ✓   TransposeNaive CPU/CUDA -> correct ✓
```

Tests: 398 generator + the runtime resilience regression tests green; solution builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
