### PR TITLE
fix(#182): CUDA-assembly type-load bug + driver-API diagnostics + CUDA_PATH probing

### DIFF
--- a/src/Backends/DotCompute.Backends.CUDA/CudaBackendFactory.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/CudaBackendFactory.cs
@@ -20,6 +20,10 @@ namespace DotCompute.Backends.CUDA
     public class CudaBackendFactory(ILogger<CudaBackendFactory>? logger = null) : IBackendFactory
     {
         private readonly ILogger<CudaBackendFactory> _logger = logger ?? new NullLogger<CudaBackendFactory>();
+
+        // IsAvailable() is invoked several times during discovery/validation; log the detailed
+        // toolkit-missing diagnosis once per process instead of once per call.
+        private static int _toolkitMissingDiagnosisLogged;
         /// <summary>
         /// Gets or sets the name.
         /// </summary>
@@ -49,7 +53,8 @@ namespace DotCompute.Backends.CUDA
 
                 if (result != CudaError.Success)
                 {
-                    _logger.LogWarningMessage($"");
+                    _logger.LogWarningMessage(
+                        $"cudaGetDeviceCount failed with {result}. CUDA backend is not available (the CUDA runtime loaded, but no usable device/driver was found — check that the NVIDIA driver version supports the installed CUDA Toolkit).");
                     return false;
                 }
 
@@ -60,7 +65,42 @@ namespace DotCompute.Backends.CUDA
             }
             catch (DllNotFoundException)
             {
-                _logger.LogWarningMessage("CUDA runtime library not found. CUDA backend is not available.");
+                // cudart (part of the CUDA *Toolkit*) is missing. Use the *driver* API — nvcuda.dll /
+                // libcuda.so ships with the GPU driver on every machine with an NVIDIA driver — to
+                // tell the user whether they have a usable GPU that merely lacks the toolkit (GH #182:
+                // driver-only frameworks like ILGPU work on such machines, so a bare "CUDA not found"
+                // reads as a DotCompute bug instead of a missing prerequisite).
+                try
+                {
+                    if (CudaRuntime.cuInit(0) == CudaError.Success
+                        && CudaRuntime.cuDeviceGetCount(out var driverDeviceCount) == CudaError.Success
+                        && driverDeviceCount > 0)
+                    {
+                        if (Interlocked.Exchange(ref _toolkitMissingDiagnosisLogged, 1) == 0)
+                        {
+                            var driverCuda = CudaRuntime.cuDriverGetVersion(out var driverVersion) == CudaError.Success
+                                ? $"{driverVersion / 1000}.{driverVersion % 1000 / 10}"
+                                : "unknown";
+                            _logger.LogWarningMessage(
+                                $"An NVIDIA GPU and driver were detected ({driverDeviceCount} device(s), driver supports CUDA {driverCuda}), " +
+                                "but the CUDA Toolkit runtime (cudart64_*.dll / libcudart.so) was not found. " +
+                                "The CUDA backend compiles kernels with NVRTC and requires the CUDA Toolkit 12.0 or newer: " +
+                                "install it from https://developer.nvidia.com/cuda-downloads, or ensure its bin directory is on PATH " +
+                                "(the CUDA_PATH environment variable set by the installer is also probed).");
+                        }
+                        return false;
+                    }
+                }
+                catch (DllNotFoundException)
+                {
+                    // No driver library either — genuinely no NVIDIA GPU/driver on this machine.
+                }
+                catch (EntryPointNotFoundException)
+                {
+                    // Driver library present but too old to export the probed entry points.
+                }
+
+                _logger.LogWarningMessage("CUDA runtime library not found and no NVIDIA driver detected. CUDA backend is not available.");
                 return false;
             }
             catch (Exception ex)

--- a/src/Backends/DotCompute.Backends.CUDA/Types/Native/CudaRuntime.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/Types/Native/CudaRuntime.cs
@@ -116,6 +116,14 @@ namespace DotCompute.Backends.CUDA.Native
                         return handle;
                     }
                 }
+
+                // Bare-name probing searches PATH; if the toolkit is installed but its bin dir is
+                // not on PATH (common on Windows), probe the toolkit install locations directly.
+                var toolkitHandle = TryLoadFromWindowsCudaToolkit("cudart64_*.dll");
+                if (toolkitHandle != IntPtr.Zero)
+                {
+                    return toolkitHandle;
+                }
             }
             // CUDA driver API: "cuda" / "nvcuda".
             else if (libraryName is "cuda" or "nvcuda")
@@ -143,6 +151,14 @@ namespace DotCompute.Backends.CUDA.Native
                         return handle;
                     }
                 }
+
+                // Note: the pattern matches nvrtc64_*.dll only, not nvrtc-builtins64_*.dll — the
+                // builtins library is loaded by NVRTC itself from its own directory.
+                var toolkitHandle = TryLoadFromWindowsCudaToolkit("nvrtc64_*.dll");
+                if (toolkitHandle != IntPtr.Zero)
+                {
+                    return toolkitHandle;
+                }
             }
 
             return IntPtr.Zero;
@@ -153,6 +169,71 @@ namespace DotCompute.Backends.CUDA.Native
             => RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                 ? ["nvrtc64_130_0", "nvrtc64_120_0", "nvrtc64_112_0", "nvrtc64_111_0", "nvrtc64_110_0", "nvrtc64_102_0", "nvrtc64_101_0", "nvrtc64"]
                 : ["libnvrtc.so.13", "libnvrtc.so.12", "libnvrtc.so.11", "libnvrtc.so"];
+
+        /// <summary>
+        /// Windows fallback: probes CUDA Toolkit install locations directly for a native library,
+        /// covering toolkits whose bin directory is not on PATH. Sources, in order: the
+        /// <c>CUDA_PATH</c> / <c>CUDA_PATH_V*</c> environment variables set by the toolkit
+        /// installer, then the default install root. Returns the newest matching library that
+        /// loads, or <see cref="IntPtr.Zero"/>. No-op on non-Windows.
+        /// </summary>
+        private static IntPtr TryLoadFromWindowsCudaToolkit(string filePattern)
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return IntPtr.Zero;
+            }
+
+            var binDirs = new List<string>();
+            try
+            {
+                foreach (System.Collections.DictionaryEntry entry in Environment.GetEnvironmentVariables())
+                {
+                    if (entry.Key is string key
+                        && (key.Equals("CUDA_PATH", StringComparison.OrdinalIgnoreCase)
+                            || key.StartsWith("CUDA_PATH_V", StringComparison.OrdinalIgnoreCase))
+                        && entry.Value is string root
+                        && !string.IsNullOrEmpty(root))
+                    {
+                        binDirs.Add(Path.Combine(root, "bin"));
+                    }
+                }
+
+                const string DefaultToolkitRoot = @"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA";
+                if (Directory.Exists(DefaultToolkitRoot))
+                {
+                    // Numeric version sort — lexicographic ordering would rank "v9.0" above "v13.0".
+                    binDirs.AddRange(Directory.GetDirectories(DefaultToolkitRoot, "v*")
+                        .OrderByDescending(d => Version.TryParse(Path.GetFileName(d).TrimStart('v', 'V'), out var v) ? v : new Version(0, 0))
+                        .Select(d => Path.Combine(d, "bin")));
+                }
+
+                foreach (var binDir in binDirs.Distinct(StringComparer.OrdinalIgnoreCase))
+                {
+                    if (!Directory.Exists(binDir))
+                    {
+                        continue;
+                    }
+
+                    foreach (var file in Directory.GetFiles(binDir, filePattern)
+                                                  .OrderByDescending(f => f, StringComparer.OrdinalIgnoreCase))
+                    {
+                        if (NativeLibrary.TryLoad(file, out var handle))
+                        {
+                            return handle;
+                        }
+                    }
+                }
+            }
+#pragma warning disable CA1031 // Do not catch general exception types - probing must never throw; the default loader remains the fallback
+            catch
+#pragma warning restore CA1031
+            {
+                // Ignore probing errors (permissions, malformed env vars) — fall through to Zero.
+            }
+
+            return IntPtr.Zero;
+        }
 
         // Device Management - Using DllImport for enum support
         [DllImport(CUDA_LIBRARY)]

--- a/src/Backends/DotCompute.Backends.CUDA/Types/Native/CudaRuntime.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/Types/Native/CudaRuntime.cs
@@ -195,6 +195,8 @@ namespace DotCompute.Backends.CUDA.Native
                         && entry.Value is string root
                         && !string.IsNullOrEmpty(root))
                     {
+                        // CUDA 13+ places Windows DLLs under bin\x64; earlier toolkits use bin.
+                        binDirs.Add(Path.Combine(root, "bin", "x64"));
                         binDirs.Add(Path.Combine(root, "bin"));
                     }
                 }
@@ -203,9 +205,12 @@ namespace DotCompute.Backends.CUDA.Native
                 if (Directory.Exists(DefaultToolkitRoot))
                 {
                     // Numeric version sort — lexicographic ordering would rank "v9.0" above "v13.0".
-                    binDirs.AddRange(Directory.GetDirectories(DefaultToolkitRoot, "v*")
-                        .OrderByDescending(d => Version.TryParse(Path.GetFileName(d).TrimStart('v', 'V'), out var v) ? v : new Version(0, 0))
-                        .Select(d => Path.Combine(d, "bin")));
+                    foreach (var versionDir in Directory.GetDirectories(DefaultToolkitRoot, "v*")
+                        .OrderByDescending(d => Version.TryParse(Path.GetFileName(d).TrimStart('v', 'V'), out var v) ? v : new Version(0, 0)))
+                    {
+                        binDirs.Add(Path.Combine(versionDir, "bin", "x64"));
+                        binDirs.Add(Path.Combine(versionDir, "bin"));
+                    }
                 }
 
                 foreach (var binDir in binDirs.Distinct(StringComparer.OrdinalIgnoreCase))

--- a/src/Backends/DotCompute.Backends.CUDA/Types/Native/Delegates/CudaNativeDelegates.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/Types/Native/Delegates/CudaNativeDelegates.cs
@@ -23,9 +23,9 @@ namespace DotCompute.Backends.CUDA.Types.Native.Delegates
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate nint CudaFunc();
 
-    /// <summary>
-    /// CUDA event delegate
-    /// </summary>
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate nint CudaEvent();
+    // NOTE: do not declare a delegate named "CudaEvent" here. A CUevent is an opaque driver
+    // HANDLE (nint), not a callback. A delegate by that name silently satisfied the
+    // programmaticEvent member of the CudaLaunchAttributeValue union, and — being a managed
+    // reference type at a [FieldOffset] — made the CLR refuse to load that struct, which broke
+    // reflection over this entire assembly (GH #182).
 }

--- a/src/Backends/DotCompute.Backends.CUDA/Types/Native/Structs/CudaLaunchStructs.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/Types/Native/Structs/CudaLaunchStructs.cs
@@ -91,9 +91,44 @@ namespace DotCompute.Backends.CUDA.Types.Native.Structs
     }
 
     /// <summary>
-    /// CUDA launch attribute value union structure
+    /// Programmatic-event member of the launch-attribute union. Mirrors the native
+    /// <c>struct { CUevent event; int flags; int triggerAtBlockStart; }</c>. The event is an
+    /// opaque driver handle, represented as <see cref="nint"/> — a managed reference type here
+    /// (the old <c>CudaEvent</c> delegate) made the containing explicit-layout union fail to
+    /// load on every platform (GH #182).
     /// </summary>
-    [StructLayout(LayoutKind.Explicit)]
+    [StructLayout(LayoutKind.Sequential)]
+    public struct CudaProgrammaticEvent
+    {
+        /// <summary>The CUevent handle.</summary>
+        public nint @event;
+        /// <summary>Event record flags.</summary>
+        public int flags;
+        /// <summary>Nonzero to trigger the event at block start rather than block end.</summary>
+        public int triggerAtBlockStart;
+    }
+
+    /// <summary>
+    /// Launch-completion-event member of the launch-attribute union. Mirrors the native
+    /// <c>struct { CUevent event; int flags; }</c>.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct CudaLaunchCompletionEvent
+    {
+        /// <summary>The CUevent handle.</summary>
+        public nint @event;
+        /// <summary>Event record flags.</summary>
+        public int flags;
+    }
+
+    /// <summary>
+    /// CUDA launch attribute value union structure. Mirrors the native
+    /// <c>CUlaunchAttributeValue</c> union, which is padded to 64 bytes (<c>char pad[64]</c>).
+    /// Every overlapped member must be an unmanaged type: a managed reference (class, delegate,
+    /// array) at a [FieldOffset] makes the CLR refuse to load the type — and with it fail
+    /// reflection over this entire assembly (GH #182).
+    /// </summary>
+    [StructLayout(LayoutKind.Explicit, Size = 64)]
     public struct CudaLaunchAttributeValue
     {
         /// <summary>
@@ -123,7 +158,7 @@ namespace DotCompute.Backends.CUDA.Types.Native.Structs
         /// <summary>
         /// The programmatic event.
         /// </summary>
-        [FieldOffset(0)] public CudaEvent programmaticEvent;
+        [FieldOffset(0)] public CudaProgrammaticEvent programmaticEvent;
         /// <summary>
         /// The priority.
         /// </summary>
@@ -139,7 +174,7 @@ namespace DotCompute.Backends.CUDA.Types.Native.Structs
         /// <summary>
         /// The launch completion event.
         /// </summary>
-        [FieldOffset(0)] public ulong launchCompletionEvent;
+        [FieldOffset(0)] public CudaLaunchCompletionEvent launchCompletionEvent;
         /// <summary>
         /// The device updatable kernel node.
         /// </summary>
@@ -148,11 +183,6 @@ namespace DotCompute.Backends.CUDA.Types.Native.Structs
         /// The preferred shmem carveout.
         /// </summary>
         [FieldOffset(0)] public uint preferredShmemCarveout;
-
-
-
-
-
     }
 
     /// <summary>

--- a/tests/Unit/DotCompute.Backends.CUDA.Tests/AssemblyTypeLoadTests.cs
+++ b/tests/Unit/DotCompute.Backends.CUDA.Tests/AssemblyTypeLoadTests.cs
@@ -1,0 +1,54 @@
+// Copyright (c) 2025 Michael Ivertowski
+// Licensed under the MIT License. See LICENSE file in the project root for license information.
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+using DotCompute.Backends.CUDA.Types.Native.Structs;
+using FluentAssertions;
+using Xunit;
+
+namespace DotCompute.Backends.CUDA.Tests;
+
+/// <summary>
+/// Regression coverage for GH #182: every type in the CUDA backend assembly must be loadable.
+/// A [StructLayout(LayoutKind.Explicit)] union with a managed reference (class/delegate/array)
+/// at a [FieldOffset] fails CLR type loading on every platform — and because kernel discovery
+/// reflects over the whole assembly with <see cref="Module.GetTypes()"/>, one such struct made
+/// the entire assembly unscannable ("Error scanning assembly DotCompute.Backends.CUDA").
+/// The C# compiler does NOT catch this; only forcing the types to load does.
+/// </summary>
+[Trait("Category", "Unit")]
+public sealed class AssemblyTypeLoadTests
+{
+    [Fact]
+    public void AllTypesInCudaBackendAssembly_CanBeLoaded()
+    {
+        // Exactly what GeneratedKernelDiscoveryService does when scanning assemblies.
+        var act = () => typeof(CudaAccelerator).Assembly.GetTypes();
+
+        _ = act.Should().NotThrow<ReflectionTypeLoadException>(
+            "kernel discovery reflects over this assembly; a single unloadable type (e.g. an " +
+            "explicit-layout union with a managed reference field) breaks the whole scan");
+    }
+
+    [Fact]
+    public void CudaLaunchAttributeValue_LoadsAndMatchesNativeUnionSize()
+    {
+        // Marshal.SizeOf forces the type to load (threw TypeLoadException before the fix, when
+        // programmaticEvent was the managed CudaEvent delegate) and validates the native ABI:
+        // CUlaunchAttributeValue is padded to 64 bytes (char pad[64]).
+        _ = Marshal.SizeOf<CudaLaunchAttributeValue>().Should().Be(64);
+    }
+
+    [Fact]
+    public void CudaLaunchAttributeValue_UnionMembers_AreAllUnmanaged()
+    {
+        // Guard against reintroducing a reference-type member into the union.
+        foreach (var field in typeof(CudaLaunchAttributeValue).GetFields(BindingFlags.Public | BindingFlags.Instance))
+        {
+            _ = field.FieldType.IsValueType.Should().BeTrue(
+                $"union member '{field.Name}' must be an unmanaged value type; a managed reference " +
+                "at a [FieldOffset] makes the CLR refuse to load the struct");
+        }
+    }
+}


### PR DESCRIPTION
Third follow-up for #182, driven by the reporter's warning-level logs and the observation that **ILGPU works on the same Windows machines where DotCompute reports "CUDA runtime library not found"**.

## Why ILGPU works there and DotCompute doesn't (investigated from ILGPU's source)

ILGPU's CUDA backend requires exactly **one** native library on Windows: `nvcuda.dll` — the **driver API**, installed into System32 by the NVIDIA display driver (`Src/ILGPU/Runtime/Cuda/CudaAPI.xml`: `<Windows>nvcuda</Windows>`; zero references to cudart or NVRTC in its core). It compiles MSIL→PTX entirely in managed code and lets the driver JIT the PTX via `cuModuleLoadDataEx`. DotCompute instead compiles generated CUDA-C at run time with **NVRTC** and uses the **cudart** runtime API — both ship only with the **CUDA Toolkit** (`cudart64_*.dll`, `nvrtc64_*_0.dll`). `nvidia-smi`'s "CUDA Version" is the *driver's* supported version, not evidence a toolkit is installed. So on driver-only machines, ILGPU runs and DotCompute correctly finds no runtime — but our message made it look like a DotCompute bug.

## Fix 1 — `CudaLaunchAttributeValue` broke type loading of the whole CUDA assembly

The reporter's logs showed every discovery scan failing:
```
ReflectionTypeLoadException: Could not load type 'CudaLaunchAttributeValue' ... contains an
object field at offset 0 that is incorrectly aligned or overlapped by a non-object field.
```
`[FieldOffset(0)] public CudaEvent programmaticEvent;` didn't reference a handle struct — it resolved to `public delegate nint CudaEvent();` (a **delegate**, i.e. a managed reference type) via a name collision. The CLR refuses such structs on **every platform** (Linux hit it too; the log was just swallowed). Fixed to match the native `CUlaunchAttributeValue` ABI: `CudaProgrammaticEvent { nint event; int flags; int triggerAtBlockStart; }`, `launchCompletionEvent` `ulong` → `CudaLaunchCompletionEvent { nint event; int flags; }`, union declared `Size = 64` (native `char pad[64]`; `CudaLaunchAttribute` now marshals at the correct 72-byte stride), and the misleading delegate deleted. Regression tests verified **red on the old struct with the reporter's exact exception** → green now (assembly-wide `GetTypes()`, `Marshal.SizeOf == 64`, all-members-unmanaged guard).

## Fix 2 — actionable detection + toolkit probing (ILGPU-style two-tier)

- `IsAvailable()`: when cudart is missing, probe the **driver API** (`cuInit` + `cuDeviceGetCount` + `cuDriverGetVersion` — the resolver maps `nvcuda`/`libcuda` per OS). GPU + driver present → warn once: *"NVIDIA GPU and driver detected (N device(s), driver supports CUDA X.Y), but the CUDA Toolkit runtime was not found. Install CUDA Toolkit 12.0+ … or ensure its bin is on PATH (CUDA_PATH is also probed)."* Only with no driver at all does it report no-NVIDIA-GPU.
- Fixed the **empty warning** (`$""`) that swallowed the `CudaError` when `cudaGetDeviceCount` failed.
- `ResolveCudaLibrary` (Windows): if PATH probing fails, probe toolkit install locations directly — `%CUDA_PATH%` / `%CUDA_PATH_V*%` and the default Program Files root, newest-first with a **numeric** version sort (lexicographic ranked v9.0 above v13.0) — for both `cudart64_*.dll` and `nvrtc64_*.dll`. Covers toolkits installed without bin on PATH.

## Verification

- Regression tests red→green with the reporter's exact `TypeLoadException`; 772 CUDA unit tests pass; solution builds clean.
- **A10 (Linux): full e2e still green** — the reporter's exact global-namespace `Add` + `TransposeNaive` compile via NVRTC and execute correctly on CPU **and** CUDA.
- Windows runtime verification requested from the reporter (no local Windows box); by construction the changes only add fallbacks/diagnostics.

Follow-ups noted during the audit (separate tickets): `CudaKernelFunc` delegate passed where native expects `const void* func` in `CudaRuntimeExtended*.cs`; those two files are byte-identical duplicates; `CudaRuntimeCore`'s static-ctor resolver is dead code since the `[ModuleInitializer]` registers first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
