### PR TITLE
fix(#182): CUBIN targets real device arch (was hardcoded sm_86) + PTX fallback + Git Bash script fix

### DIFF
--- a/scripts/download-cuda-natives.sh
+++ b/scripts/download-cuda-natives.sh
@@ -18,6 +18,17 @@ CACHE="${CUDA_NATIVES_CACHE:-$REPO_ROOT/artifacts/cuda-natives-cache}"
 BASE=https://developer.download.nvidia.com/compute/cuda/redist
 mkdir -p "$OUT" "$CACHE"
 
+# Python is needed to extract the Linux tarballs (their symlinks cannot be extracted by tar on
+# Windows). Git Bash on Windows ships `python` (not `python3`) — accept either.
+if command -v python3 >/dev/null 2>&1; then
+  PYTHON=python3
+elif command -v python >/dev/null 2>&1; then
+  PYTHON=python
+else
+  echo "ERROR: python3 (or python) is required to extract the Linux archives. Install Python and re-run." >&2
+  exit 1
+fi
+
 # name|relative_path|sha256
 ARCHIVES=(
   "cuda_cudart-windows-x86_64-13.0.96-archive.zip|cuda_cudart/windows-x86_64|a2ed875f9997aa24904fb70cc9db3acd9308433cde99bc8e63ec1271c9da31b4"
@@ -65,7 +76,7 @@ extract_linux() { # tar.xz, dest, sonames... (resolve symlinks IN-ARCHIVE, write
   # its SONAME name anyway (NuGet packages cannot contain symlinks).
   local tarball="$1" dest="$2"; shift 2
   mkdir -p "$dest"
-  python3 - "$tarball" "$dest" "$@" <<'PY'
+  "$PYTHON" - "$tarball" "$dest" "$@" <<'PY'
 import os, posixpath, sys, tarfile
 tarball, dest, *sonames = sys.argv[1:]
 with tarfile.open(tarball, "r:xz") as tf:

--- a/src/Backends/DotCompute.Backends.CUDA/Compilation/CubinCompiler.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/Compilation/CubinCompiler.cs
@@ -168,8 +168,8 @@ internal static partial class CubinCompiler
         // Set target architecture for CUBIN (uses compute capability directly)
         compilationOptions.Add($"--gpu-architecture=sm_{major}{minor}");
 
-        // Add CUDA include path for system headers (cooperative_groups.h, device_functions.h, etc.)
-        compilationOptions.Add("--include-path=/usr/local/cuda/include");
+        // CUDA Toolkit include dirs for system headers, resolved cross-platform.
+        compilationOptions.AddRange(NvrtcIncludePaths.GetIncludePathOptions());
 
         // Note: NVRTC handles optimization internally and doesn't accept GCC-style -O flags
         // In CUDA 13.0+, passing -O flags causes "unrecognized option" errors
@@ -206,13 +206,15 @@ internal static partial class CubinCompiler
     }
 
     /// <summary>
-    /// Gets the target compute capability for CUBIN compilation.
+    /// Gets the target compute capability for CUBIN compilation — the ACTUAL device's capability
+    /// via <see cref="Configuration.CudaCapabilityManager"/>. A CUBIN is native SASS: unlike PTX it
+    /// only loads on GPUs of the same compute-capability major (and equal-or-higher minor). This
+    /// used to be hardcoded to (8,6), which happened to work on sm_86/sm_89 dev machines but made
+    /// every kernel fail to load with CUDA_ERROR_NO_BINARY_FOR_GPU on any other GPU — e.g. the
+    /// GH #182 reporter's GTX 1650 (sm_75) — surfacing as "Compilation pipeline failed".
     /// </summary>
     private static (int major, int minor) GetTargetComputeCapability()
-        // For CUBIN, we target the actual device capability
-        // Cap at compute_86 for CUDA 12.8 compatibility
-
-        => (8, 6);
+        => Configuration.CudaCapabilityManager.GetTargetComputeCapability();
 
     /// <summary>
     /// Checks if debug mode is enabled.

--- a/src/Backends/DotCompute.Backends.CUDA/Compilation/CudaCompilationPipeline.LoggerMessages.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/Compilation/CudaCompilationPipeline.LoggerMessages.cs
@@ -47,6 +47,10 @@ internal sealed partial class CudaCompilationPipeline
         Message = "Batch compilation failed after {ElapsedMs}ms")]
     private static partial void LogBatchFailure(ILogger logger, Exception ex, long elapsedMs);
 
+    [LoggerMessage(EventId = 21012, Level = LogLevel.Warning,
+        Message = "CUBIN for kernel {KernelName} was rejected by the device; retrying with PTX (driver JIT)")]
+    private static partial void LogCubinLoadFailedFallingBackToPtx(ILogger logger, Exception ex, string kernelName);
+
     [LoggerMessage(EventId = 21010, Level = LogLevel.Warning,
         Message = "Failed to determine optimal compilation target, defaulting to PTX")]
     private static partial void LogTargetSelectionFailed(ILogger logger, Exception ex);

--- a/src/Backends/DotCompute.Backends.CUDA/Compilation/CudaCompilationPipeline.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/Compilation/CudaCompilationPipeline.cs
@@ -181,49 +181,21 @@ internal sealed partial class CudaCompilationPipeline : IDisposable
             var compilationTarget = DetermineCompilationTarget(options);
             LogCompilationTarget(_logger, compilationTarget, source.Name);
 
-            // Phase 5: Compile kernel
-            byte[] compiledCode;
-            switch (compilationTarget)
+            // Phases 5-7: compile + load, with a PTX fallback when a CUBIN fails to LOAD.
+            // A CUBIN is native SASS for one compute-capability major; if the driver rejects it
+            // (e.g. NoBinaryForGpu on hardware the target selection did not anticipate), PTX still
+            // works everywhere because the driver JIT-compiles it for the actual device (GH #182).
+            CudaCompiledKernel compiledKernel;
+            try
             {
-                case CompilationTarget.CUBIN:
-                    compiledCode = await CubinCompiler.CompileToCubinAsync(source.Code, source.Name, options, _logger)
-                        .ConfigureAwait(false);
-                    break;
-
-
-                case CompilationTarget.PTX:
-                default:
-                    compiledCode = await PTXCompiler.CompileToPtxAsync(source.Code, source.Name, options, _logger)
-                        .ConfigureAwait(false);
-                    break;
+                compiledKernel = await CompileAndCreateKernelAsync(source, options, compilationTarget).ConfigureAwait(false);
             }
-
-            // Phase 5.5: Inject timestamp recording if enabled
-            if (_timingProvider?.IsTimestampInjectionEnabled == true && compilationTarget == CompilationTarget.PTX)
+            catch (InvalidOperationException ex) when (compilationTarget == CompilationTarget.CUBIN)
             {
-                compiledCode = TimestampInjector.InjectTimestampIntoPtx(compiledCode, source.Name, _logger);
+                LogCubinLoadFailedFallingBackToPtx(_logger, ex, source.Name);
+                compilationTarget = CompilationTarget.PTX;
+                compiledKernel = await CompileAndCreateKernelAsync(source, options, compilationTarget).ConfigureAwait(false);
             }
-
-            // Phase 5.6: Inject memory fences if service is configured with pending requests
-            if (_fenceInjectionService?.PendingFenceCount > 0 && compilationTarget == CompilationTarget.PTX)
-            {
-                compiledCode = FenceInjector.InjectFencesIntoPtx(compiledCode, source.Name, _fenceInjectionService, _logger);
-            }
-
-            // Phase 6: Verify compiled code
-            if (!CudaCompilerValidator.VerifyCompiledCode(compiledCode, source.Name, _logger))
-            {
-                LogVerificationFailed(_logger, source.Name);
-            }
-
-            // Phase 7: Create compiled kernel object
-            var compiledKernel = new CudaCompiledKernel(
-                _context,
-                source.Name,
-                source.EntryPoint,
-                compiledCode,
-                options,
-                _logger);
 
             // Phase 8: Cache the result
             await _cache.CacheKernelAsync(cacheKey, compiledKernel, definition, options).ConfigureAwait(false);
@@ -237,8 +209,63 @@ internal sealed partial class CudaCompilationPipeline : IDisposable
         {
             stopwatch.Stop();
             LogCompilationFailure(_logger, ex, definition.Name, stopwatch.ElapsedMilliseconds);
-            throw new KernelCompilationException($"Compilation pipeline failed for kernel '{definition.Name}'", ex);
+            // Include the cause in the message: users routinely paste only the top of the
+            // exception chain (GH #182), and a bare "pipeline failed" hides the actual error.
+            throw new KernelCompilationException($"Compilation pipeline failed for kernel '{definition.Name}': {ex.Message}", ex);
         }
+    }
+
+    /// <summary>
+    /// Pipeline phases 5-7 for one compilation target: NVRTC compile (CUBIN or PTX), PTX-only
+    /// timestamp/fence injection, verification, and module load into a compiled-kernel object.
+    /// </summary>
+    private async Task<CudaCompiledKernel> CompileAndCreateKernelAsync(
+        KernelSource source,
+        CompilationOptions? options,
+        CompilationTarget compilationTarget)
+    {
+        // Phase 5: Compile kernel
+        byte[] compiledCode;
+        switch (compilationTarget)
+        {
+            case CompilationTarget.CUBIN:
+                compiledCode = await CubinCompiler.CompileToCubinAsync(source.Code, source.Name, options, _logger)
+                    .ConfigureAwait(false);
+                break;
+
+            case CompilationTarget.PTX:
+            default:
+                compiledCode = await PTXCompiler.CompileToPtxAsync(source.Code, source.Name, options, _logger)
+                    .ConfigureAwait(false);
+                break;
+        }
+
+        // Phase 5.5: Inject timestamp recording if enabled
+        if (_timingProvider?.IsTimestampInjectionEnabled == true && compilationTarget == CompilationTarget.PTX)
+        {
+            compiledCode = TimestampInjector.InjectTimestampIntoPtx(compiledCode, source.Name, _logger);
+        }
+
+        // Phase 5.6: Inject memory fences if service is configured with pending requests
+        if (_fenceInjectionService?.PendingFenceCount > 0 && compilationTarget == CompilationTarget.PTX)
+        {
+            compiledCode = FenceInjector.InjectFencesIntoPtx(compiledCode, source.Name, _fenceInjectionService, _logger);
+        }
+
+        // Phase 6: Verify compiled code
+        if (!CudaCompilerValidator.VerifyCompiledCode(compiledCode, source.Name, _logger))
+        {
+            LogVerificationFailed(_logger, source.Name);
+        }
+
+        // Phase 7: Create compiled kernel object (loads the module on the device)
+        return new CudaCompiledKernel(
+            _context,
+            source.Name,
+            source.EntryPoint,
+            compiledCode,
+            options,
+            _logger);
     }
 
     /// <summary>

--- a/src/Backends/DotCompute.Backends.CUDA/Compilation/NvrtcIncludePaths.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/Compilation/NvrtcIncludePaths.cs
@@ -1,0 +1,80 @@
+// Copyright (c) 2025 Michael Ivertowski
+// Licensed under the MIT License. See LICENSE file in the project root for license information.
+
+namespace DotCompute.Backends.CUDA.Compilation;
+
+/// <summary>
+/// Cross-platform CUDA Toolkit include directories for NVRTC (<c>--include-path=...</c> options).
+/// Previously the compilers hardcoded <c>/usr/local/cuda/include</c>, which does not exist on
+/// Windows — harmless for the include-free generated kernels, but wrong for any kernel using
+/// system headers (cooperative_groups.h, cuda::std::). Only directories that actually exist are
+/// returned, so machines without a toolkit (e.g. natives-package deployments, GH #187) get none.
+/// </summary>
+internal static class NvrtcIncludePaths
+{
+    /// <summary>Builds the NVRTC <c>--include-path</c> options for the current machine.</summary>
+    public static IReadOnlyList<string> GetIncludePathOptions()
+    {
+        var options = new List<string>();
+
+        foreach (var root in GetToolkitRoots().Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            var include = Path.Combine(root, "include");
+            if (Directory.Exists(include))
+            {
+                options.Add($"--include-path={include}");
+
+                // CCCL (cuda::std::) headers, required by cooperative_groups on CUDA 11.1+.
+                var cccl = Path.Combine(include, "cccl");
+                if (Directory.Exists(cccl))
+                {
+                    options.Add($"--include-path={cccl}");
+                }
+            }
+
+            // Linux toolkit layout keeps CCCL under targets/<arch>/include/cccl.
+            var linuxCccl = Path.Combine(root, "targets", "x86_64-linux", "include", "cccl");
+            if (Directory.Exists(linuxCccl))
+            {
+                options.Add($"--include-path={linuxCccl}");
+            }
+
+            if (options.Count > 0)
+            {
+                break; // first toolkit that provides headers wins (newest first on Windows)
+            }
+        }
+
+        return options;
+    }
+
+    private static IEnumerable<string> GetToolkitRoots()
+    {
+        foreach (var variable in new[] { "CUDA_PATH", "CUDA_HOME" })
+        {
+            if (Environment.GetEnvironmentVariable(variable) is { Length: > 0 } value)
+            {
+                yield return value;
+            }
+        }
+
+        if (OperatingSystem.IsWindows())
+        {
+            const string DefaultToolkitRoot = @"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA";
+            if (Directory.Exists(DefaultToolkitRoot))
+            {
+                // Numeric version sort — lexicographic would rank v9.0 above v13.0.
+                foreach (var dir in Directory.GetDirectories(DefaultToolkitRoot, "v*")
+                    .OrderByDescending(d => Version.TryParse(Path.GetFileName(d).TrimStart('v', 'V'), out var v) ? v : new Version(0, 0)))
+                {
+                    yield return dir;
+                }
+            }
+        }
+        else
+        {
+            yield return "/usr/local/cuda";
+            yield return "/opt/cuda";
+        }
+    }
+}

--- a/src/Backends/DotCompute.Backends.CUDA/Compilation/PTXCompiler.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/Compilation/PTXCompiler.cs
@@ -233,12 +233,9 @@ internal static partial class PTXCompiler
         // Set target compute capability
         compilationOptions.Add($"--gpu-architecture=compute_{major}{minor}");
 
-        // Add CUDA include path for system headers (cooperative_groups.h, device_functions.h, etc.)
-        compilationOptions.Add("--include-path=/usr/local/cuda/include");
-
-        // Add CCCL (CUDA C++ Core Libraries) include path for cuda::std:: headers
-        // Required for cooperative_groups when using CUDA C++ Standard Library (CUDA 11.1+)
-        compilationOptions.Add("--include-path=/usr/local/cuda/targets/x86_64-linux/include/cccl");
+        // CUDA Toolkit include dirs for system headers (cooperative_groups.h, cuda::std::, ...),
+        // resolved cross-platform (CUDA_PATH / Program Files on Windows, /usr/local/cuda on Linux).
+        compilationOptions.AddRange(NvrtcIncludePaths.GetIncludePathOptions());
 
         // Note: NVRTC handles optimization internally and doesn't accept GCC-style -O flags
         // In CUDA 13.0+, passing -O flags causes "unrecognized option" errors

--- a/src/Backends/DotCompute.Backends.CUDA/Kernels/CudaCompiledKernel.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/Kernels/CudaCompiledKernel.cs
@@ -196,6 +196,12 @@ namespace DotCompute.Backends.CUDA.Compilation
                             $"Target compute capability: sm_{computeCapability.major}{computeCapability.minor}, " +
                             $"PTX version: {ptxVersion}, " +
                             $"PTX size: {_ptxData.Length} bytes";
+                        if (result == CudaError.NoBinaryForGpu)
+                        {
+                            errorDetails += ". The compiled binary's architecture does not match this GPU " +
+                                "(a CUBIN only loads on the compute-capability major it was compiled for) — " +
+                                "if this persists on latest DotCompute, please report it with your GPU model.";
+                        }
 
 
                         throw new InvalidOperationException(errorDetails);

--- a/src/Backends/DotCompute.Backends.CUDA/Types/Native/CudaError.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/Types/Native/CudaError.cs
@@ -423,6 +423,24 @@ namespace DotCompute.Backends.CUDA.Types.Native
         ContextIsDestroyed = 202,
 
         /// <summary>
+        /// The device kernel image is invalid (CUDA_ERROR_INVALID_IMAGE).
+        /// </summary>
+        InvalidImage = 200,
+
+        /// <summary>
+        /// No kernel image (CUBIN/PTX) in the loaded binary is compatible with this device
+        /// (CUDA_ERROR_NO_BINARY_FOR_GPU / cudaErrorNoKernelImageForDevice). Typical cause: a CUBIN
+        /// compiled for a different compute-capability major than the GPU it is loaded on.
+        /// </summary>
+        NoBinaryForGpu = 209,
+
+        /// <summary>
+        /// The PTX version is newer than the driver's JIT compiler supports
+        /// (CUDA_ERROR_UNSUPPORTED_PTX_VERSION) — typically NVRTC newer than the driver.
+        /// </summary>
+        UnsupportedPtxVersion = 222,
+
+        /// <summary>
         /// The operation is not permitted in this context.
         /// </summary>
         NotPermitted = 800,


### PR DESCRIPTION
Round 5 of #182, driven by the reporter's newest logs. Two findings, both root-caused and fixed.

## 1. The actual reason CUDA kernels never ran on their machine (any non-sm_8x GPU, in fact)

Their new error — `Failed to compile CUDA kernel ... Compilation pipeline failed` — appears **after** installing CUDA Toolkit 12.2, meaning detection now works and the failure moved to kernel compilation. Tracing the pipeline found:

**`CubinCompiler.GetTargetComputeCapability()` was hardcoded to `(8,6)`** — with a comment claiming it targets "the actual device capability". The orchestrator path always compiles CUBIN (`DefaultKernelCompiler` forces O3), so every kernel was an **sm_86 binary regardless of GPU**. A CUBIN only loads on its compute-capability major: it worked *by coincidence* on our dev hardware (A10 = sm_86 exactly, RTX 2000 Ada = sm_89 same major) and failed at `cuModuleLoadData` with `CUDA_ERROR_NO_BINARY_FOR_GPU` (209) on the reporter's Turing **sm_75** — and would fail identically on Pascal, Hopper, and Blackwell.

Fixes:
- CUBIN target now comes from `CudaCapabilityManager.GetTargetComputeCapability()` (real device query + driver-compat capping), as `PTXCompiler` already did.
- **PTX fallback**: if a CUBIN is rejected at module load, the pipeline retries as PTX (driver JIT-compiles for the actual device) — future arch surprises degrade to a slower first launch instead of a dead end.
- Diagnosability: the pipeline wrapper now includes the inner cause in its message (error 209 previously surfaced as three nested generic messages); `CudaError` gains `NoBinaryForGpu=209`, `InvalidImage=200`, `UnsupportedPtxVersion=222`; the module-load error explains the arch-mismatch cause.
- NVRTC include paths resolved cross-platform (`CUDA_PATH`/Program Files on Windows) instead of hardcoded `/usr/local/cuda`.

## 2. `download-cuda-natives.sh` died silently on Git Bash

Git Bash ships Windows Python as `python`, not `python3`; with `set -e` the script silently stopped right after the CU13 win-x64 stage — the reporter's "found 3, expected 6" pack error. The script now accepts either binary and fails loudly when neither exists.

## Verification

- A10 e2e green through the full orchestrator→CUBIN path (Add + TransposeNaive on CPU and CUDA).
- 772 CUDA unit tests pass; solution builds clean.
- Local sm_89 hardware-test failures were **baseline-checked as pre-existing** WSL2 environment issues (identical without this change).
- True sm_75 verification needs the reporter's GTX 1650 — requested in the issue. By construction the fix can only widen compatibility (real arch instead of always-sm_86, plus PTX fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
