### PR TITLE
feat(#182): loop kernels translate to CUDA, ThreadId = global index, guard-based extents

### DIFF
--- a/src/Backends/DotCompute.Backends.CUDA/CudaBackendFactory.cs
+++ b/src/Backends/DotCompute.Backends.CUDA/CudaBackendFactory.cs
@@ -84,9 +84,10 @@ namespace DotCompute.Backends.CUDA
                             _logger.LogWarningMessage(
                                 $"An NVIDIA GPU and driver were detected ({driverDeviceCount} device(s), driver supports CUDA {driverCuda}), " +
                                 "but the CUDA Toolkit runtime (cudart64_*.dll / libcudart.so) was not found. " +
-                                "The CUDA backend compiles kernels with NVRTC and requires the CUDA Toolkit 12.0 or newer: " +
-                                "install it from https://developer.nvidia.com/cuda-downloads, or ensure its bin directory is on PATH " +
-                                "(the CUDA_PATH environment variable set by the installer is also probed).");
+                                "Easiest fix: add the NuGet package DotCompute.Backends.CUDA.Natives.CU13.V2 (drivers r580+) " +
+                                "or DotCompute.Backends.CUDA.Natives.CU12.V2 (drivers r525+) — no toolkit install needed. " +
+                                "Alternatively install the CUDA Toolkit 12.0+ from https://developer.nvidia.com/cuda-downloads " +
+                                "or ensure its bin directory is on PATH (the CUDA_PATH environment variable is also probed).");
                         }
                         return false;
                     }

--- a/src/Runtime/DotCompute.Generators/Kernel/Generation/KernelExecutionMetadataEmitter.cs
+++ b/src/Runtime/DotCompute.Generators/Kernel/Generation/KernelExecutionMetadataEmitter.cs
@@ -205,7 +205,8 @@ internal static class KernelExecutionMetadataEmitter
     {
         const string indent = "                ";
 
-        // Indices (into args) of integer scalar parameters, in declaration order.
+        // Indices (into args) of integer scalar parameters, in declaration order — the fallback
+        // source of extents (trailing ints) when guard-based detection finds nothing.
         var intArgs = new List<int>();
         for (var i = 0; i < method.Parameters.Count; i++)
         {
@@ -217,20 +218,24 @@ internal static class KernelExecutionMetadataEmitter
         }
 
         var last = intArgs.Count - 1;
+        var detected = DetectExtentParamIndices(method, Math.Max(dimensions, 1));
 
-        if (dimensions >= 3 && intArgs.Count >= 3)
+        // Extent expression for a dimension: guard-detected parameter first, positional fallback second.
+        string Ext(int dim, string fallback) => detected.Length > dim && detected[dim] >= 0 ? $"(int)args[{detected[dim]}]" : fallback;
+
+        if (dimensions >= 3 && (intArgs.Count >= 3 || detected.Count(i => i >= 0) >= 3))
         {
-            _ = builder.AppendLine($"{indent}int __xext = (int)args[{intArgs[last]}];");
-            _ = builder.AppendLine($"{indent}int __yext = (int)args[{intArgs[last - 1]}];");
-            _ = builder.AppendLine($"{indent}int __zext = (int)args[{intArgs[last - 2]}];");
+            _ = builder.AppendLine($"{indent}int __xext = {Ext(0, $"(int)args[{intArgs[last]}]")};");
+            _ = builder.AppendLine($"{indent}int __yext = {Ext(1, $"(int)args[{intArgs[last - 1]}]")};");
+            _ = builder.AppendLine($"{indent}int __zext = {Ext(2, $"(int)args[{intArgs[last - 2]}]")};");
             _ = builder.AppendLine($"{indent}int __x = __i % __xext;");
             _ = builder.AppendLine($"{indent}int __y = (__i / __xext) % __yext;");
             _ = builder.AppendLine($"{indent}int __z = __i / (__xext * __yext);");
         }
-        else if (dimensions >= 2 && intArgs.Count >= 2)
+        else if (dimensions >= 2 && (intArgs.Count >= 2 || detected.Count(i => i >= 0) >= 2))
         {
-            _ = builder.AppendLine($"{indent}int __xext = (int)args[{intArgs[last]}];");
-            _ = builder.AppendLine($"{indent}int __yext = (int)args[{intArgs[last - 1]}];");
+            _ = builder.AppendLine($"{indent}int __xext = {Ext(0, intArgs.Count >= 1 ? $"(int)args[{intArgs[last]}]" : "(end - start)")};");
+            _ = builder.AppendLine($"{indent}int __yext = {Ext(1, intArgs.Count >= 2 ? $"(int)args[{intArgs[last - 1]}]" : "1")};");
             _ = builder.AppendLine($"{indent}int __zext = 1;");
             _ = builder.AppendLine($"{indent}int __x = __i % __xext;");
             _ = builder.AppendLine($"{indent}int __y = __i / __xext;");
@@ -238,7 +243,7 @@ internal static class KernelExecutionMetadataEmitter
         }
         else
         {
-            var xext = intArgs.Count > 0 ? $"(int)args[{intArgs[last]}]" : "(end - start)";
+            var xext = Ext(0, intArgs.Count > 0 ? $"(int)args[{intArgs[last]}]" : "(end - start)");
             _ = builder.AppendLine($"{indent}int __xext = {xext};");
             _ = builder.AppendLine($"{indent}int __yext = 1;");
             _ = builder.AppendLine($"{indent}int __zext = 1;");
@@ -246,6 +251,111 @@ internal static class KernelExecutionMetadataEmitter
             _ = builder.AppendLine($"{indent}int __y = 0;");
             _ = builder.AppendLine($"{indent}int __z = 0;");
         }
+    }
+
+    /// <summary>
+    /// Detects which integer scalar parameters bound each launch dimension by matching the
+    /// kernel's own guard comparisons: a coordinate derived from <c>KernelContext.ThreadId.X/Y/Z</c>
+    /// compared against an int parameter (e.g. <c>if (x &gt;= width || y &gt;= height) return;</c>
+    /// or <c>if (row &lt; rows &amp;&amp; col &lt; cols)</c>) marks that parameter as the extent for
+    /// the coordinate's dimension. Positional heuristics (trailing ints) mis-assign extents when
+    /// they are not the last parameters — e.g. Mandelbrot(output, width, height, minX.., maxIterations),
+    /// where the trailing ints are (maxIterations, height), silently computing a wrong region (GH #182).
+    /// Returns one parameter index per dimension; -1 where nothing was detected.
+    /// </summary>
+    public static int[] DetectExtentParamIndices(KernelMethodInfo method, int dimensions)
+    {
+        var result = new int[dimensions];
+        for (var i = 0; i < dimensions; i++)
+        {
+            result[i] = -1;
+        }
+
+        var body = GetBody(method);
+        if (body is null)
+        {
+            return result;
+        }
+
+        var intParams = new Dictionary<string, int>(StringComparer.Ordinal);
+        for (var i = 0; i < method.Parameters.Count; i++)
+        {
+            var param = method.Parameters[i];
+            if (!param.IsBuffer && IsIntegerType(NormalizeCSharpType(param.Type)))
+            {
+                intParams[param.Name] = i;
+            }
+        }
+
+        if (intParams.Count == 0)
+        {
+            return result;
+        }
+
+        // Locals whose initializer involves ThreadId.<axis> are coordinates for that axis.
+        var coordinateLocals = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var local in body.DescendantNodes().OfType<LocalDeclarationStatementSyntax>())
+        {
+            foreach (var declarator in local.Declaration.Variables)
+            {
+                if (declarator.Initializer is null)
+                {
+                    continue;
+                }
+
+                foreach (var memberAccess in declarator.Initializer.Value.DescendantNodesAndSelf().OfType<MemberAccessExpressionSyntax>())
+                {
+                    if (TryClassifyIntrinsic(memberAccess, out var intrinsic, out var axis) && intrinsic == "threadIdx")
+                    {
+                        coordinateLocals[declarator.Identifier.Text] = axis == "x" ? 0 : axis == "y" ? 1 : 2;
+                        break;
+                    }
+                }
+            }
+        }
+
+        int AxisOf(ExpressionSyntax expression)
+        {
+            if (expression is IdentifierNameSyntax identifier && coordinateLocals.TryGetValue(identifier.Identifier.Text, out var axis))
+            {
+                return axis;
+            }
+
+            if (expression is MemberAccessExpressionSyntax memberAccess
+                && TryClassifyIntrinsic(memberAccess, out var intrinsic, out var axisName) && intrinsic == "threadIdx")
+            {
+                return axisName == "x" ? 0 : axisName == "y" ? 1 : 2;
+            }
+
+            return -1;
+        }
+
+        foreach (var comparison in body.DescendantNodes().OfType<BinaryExpressionSyntax>())
+        {
+            var isRelational = comparison.Kind() is SyntaxKind.LessThanExpression or SyntaxKind.LessThanOrEqualExpression
+                or SyntaxKind.GreaterThanExpression or SyntaxKind.GreaterThanOrEqualExpression;
+            if (!isRelational)
+            {
+                continue;
+            }
+
+            var leftAxis = AxisOf(comparison.Left);
+            if (leftAxis >= 0 && leftAxis < dimensions && result[leftAxis] < 0
+                && comparison.Right is IdentifierNameSyntax rightId && intParams.TryGetValue(rightId.Identifier.Text, out var rightIndex))
+            {
+                result[leftAxis] = rightIndex;
+                continue;
+            }
+
+            var rightAxis = AxisOf(comparison.Right);
+            if (rightAxis >= 0 && rightAxis < dimensions && result[rightAxis] < 0
+                && comparison.Left is IdentifierNameSyntax leftId && intParams.TryGetValue(leftId.Identifier.Text, out var leftIndex))
+            {
+                result[rightAxis] = leftIndex;
+            }
+        }
+
+        return result;
     }
 
     // -------------------------------------------------------------------------------------
@@ -327,6 +437,47 @@ internal static class KernelExecutionMetadataEmitter
 
             case ReturnStatementSyntax returnStatement when returnStatement.Expression is null:
                 _ = builder.Append(indent).Append("return;").Append('\n');
+                break;
+
+            case WhileStatementSyntax whileStatement:
+                _ = builder.Append(indent).Append("while (").Append(TranslateExpressionToCuda(whileStatement.Condition)).Append(')').Append('\n');
+                EmitBranch(whileStatement.Statement, builder, indentLevel);
+                break;
+
+            case DoStatementSyntax doStatement:
+                _ = builder.Append(indent).Append("do").Append('\n');
+                EmitBranch(doStatement.Statement, builder, indentLevel);
+                _ = builder.Append(indent).Append("while (").Append(TranslateExpressionToCuda(doStatement.Condition)).Append(");").Append('\n');
+                break;
+
+            case ForStatementSyntax forStatement:
+                {
+                    string initializer;
+                    if (forStatement.Declaration is not null)
+                    {
+                        var cudaType = MapCudaType(NormalizeCSharpType(forStatement.Declaration.Type.ToString()));
+                        initializer = cudaType + " " + string.Join(", ", forStatement.Declaration.Variables.Select(v =>
+                            v.Initializer is null ? v.Identifier.Text : $"{v.Identifier.Text} = {TranslateExpressionToCuda(v.Initializer.Value)}"));
+                    }
+                    else
+                    {
+                        initializer = string.Join(", ", forStatement.Initializers.Select(TranslateExpressionToCuda));
+                    }
+
+                    var condition = forStatement.Condition is null ? string.Empty : TranslateExpressionToCuda(forStatement.Condition);
+                    var incrementors = string.Join(", ", forStatement.Incrementors.Select(TranslateExpressionToCuda));
+
+                    _ = builder.Append(indent).Append("for (").Append(initializer).Append("; ").Append(condition).Append("; ").Append(incrementors).Append(')').Append('\n');
+                    EmitBranch(forStatement.Statement, builder, indentLevel);
+                    break;
+                }
+
+            case BreakStatementSyntax:
+                _ = builder.Append(indent).Append("break;").Append('\n');
+                break;
+
+            case ContinueStatementSyntax:
+                _ = builder.Append(indent).Append("continue;").Append('\n');
                 break;
 
             default:

--- a/src/Runtime/DotCompute.Generators/Kernel/Generation/KernelExecutionMetadataEmitter.cs
+++ b/src/Runtime/DotCompute.Generators/Kernel/Generation/KernelExecutionMetadataEmitter.cs
@@ -526,8 +526,20 @@ internal static class KernelExecutionMetadataEmitter
             case CastExpressionSyntax cast:
                 return $"({MapCudaType(NormalizeCSharpType(cast.Type.ToString()))}){TranslateExpressionToCuda(cast.Expression)}";
 
+            // The [Kernel] programming model defines ThreadId as the GLOBAL thread coordinate
+            // (the CPU invoker substitutes ThreadId->global index, BlockId->0, BlockDim->extent).
+            // Mapping ThreadId to the block-local threadIdx made every CUDA block compute the
+            // same tile (GH #182 Mandelbrot: exactly one 16x16 block of correct pixels). The
+            // CUDA mapping mirrors the CPU semantics, so both the bare `ThreadId.X` style and
+            // the explicit `ThreadId.X + BlockId.X * BlockDim.X` style produce the global index.
             case MemberAccessExpressionSyntax memberAccess when TryClassifyIntrinsic(memberAccess, out var intrinsic, out var axis):
-                return $"{intrinsic}.{axis}";
+                return intrinsic switch
+                {
+                    "threadIdx" => $"(blockIdx.{axis} * blockDim.{axis} + threadIdx.{axis})",
+                    "blockIdx" => "0",
+                    "blockDim" => $"(gridDim.{axis} * blockDim.{axis})",
+                    _ => "1", // gridDim
+                };
 
             // A buffer's `.Length` maps to the implicit `__length` kernel parameter (a CUDA pointer
             // carries no length). GenerateCuda adds `__length` to the signature and flags the

--- a/src/Runtime/DotCompute.Generators/Kernel/Generation/KernelRegistrationEmitter.cs
+++ b/src/Runtime/DotCompute.Generators/Kernel/Generation/KernelRegistrationEmitter.cs
@@ -67,6 +67,7 @@ public sealed class KernelRegistrationEmitter
             var fullName = $"{method.ContainingType}.{method.Name}";
             var dimensions = KernelExecutionMetadataEmitter.DetectDimensions(method);
             var (cudaSource, cudaEntryPoint, cudaNeedsLength) = KernelExecutionMetadataEmitter.GenerateCuda(method);
+            var extentParamIndices = KernelExecutionMetadataEmitter.DetectExtentParamIndices(method, dimensions);
             var invokerClassName = KernelExecutionMetadataEmitter.GetInvokerClassName(method);
 
             _ = source.AppendLine($"            {{ \"{fullName}\", new KernelMetadata");
@@ -83,6 +84,9 @@ public sealed class KernelRegistrationEmitter
             _ = source.AppendLine($"                CudaSource = {FormatCudaSource(cudaSource)},");
             _ = source.AppendLine($"                CudaEntryPoint = {FormatNullableString(cudaEntryPoint)},");
             _ = source.AppendLine($"                CudaNeedsLength = {Bool(cudaNeedsLength)},");
+            _ = source.AppendLine(extentParamIndices.Any(i => i >= 0)
+                ? $"                ExtentParamIndices = new[] {{ {string.Join(", ", extentParamIndices)} }},"
+                : "                ExtentParamIndices = null,");
             _ = source.AppendLine($"                CpuInvoker = (System.Action<object[], int, int>){invokerClassName}.Invoke,");
             _ = source.AppendLine("                Parameters = new KernelParam[]");
             _ = source.AppendLine("                {");
@@ -174,6 +178,7 @@ public sealed class KernelRegistrationEmitter
         _ = source.AppendLine("        public string? CudaSource { get; init; }");
         _ = source.AppendLine("        public string? CudaEntryPoint { get; init; }");
         _ = source.AppendLine("        public bool CudaNeedsLength { get; init; }");
+        _ = source.AppendLine("        public int[]? ExtentParamIndices { get; init; }");
         _ = source.AppendLine("        public System.Delegate? CpuInvoker { get; init; }");
         _ = source.AppendLine("        public KernelParam[] Parameters { get; init; } = Array.Empty<KernelParam>();");
         _ = source.AppendLine("    }");

--- a/src/Runtime/DotCompute.Runtime/Services/GeneratedKernelDiscoveryService.cs
+++ b/src/Runtime/DotCompute.Runtime/Services/GeneratedKernelDiscoveryService.cs
@@ -205,6 +205,7 @@ public class GeneratedKernelDiscoveryService(ILogger<GeneratedKernelDiscoverySer
             var cudaSource = GetPropertyValue<string>(registration, "CudaSource");
             var cudaEntryPoint = GetPropertyValue<string>(registration, "CudaEntryPoint");
             var cudaNeedsLength = GetPropertyValue<bool>(registration, "CudaNeedsLength");
+            var extentParamIndices = GetPropertyValue<int[]>(registration, "ExtentParamIndices");
             var cpuInvoker = GetPropertyValue<Delegate>(registration, "CpuInvoker");
             var parameters = ExtractParameters(registration);
 
@@ -230,6 +231,7 @@ public class GeneratedKernelDiscoveryService(ILogger<GeneratedKernelDiscoverySer
                 CudaSource = string.IsNullOrEmpty(cudaSource) ? null : cudaSource,
                 CudaEntryPoint = string.IsNullOrEmpty(cudaEntryPoint) ? null : cudaEntryPoint,
                 CudaNeedsLength = cudaNeedsLength,
+                ExtentParamIndices = extentParamIndices,
                 CpuInvoker = cpuInvoker,
                 Parameters = parameters
             };

--- a/src/Runtime/DotCompute.Runtime/Services/KernelExecutionService.cs
+++ b/src/Runtime/DotCompute.Runtime/Services/KernelExecutionService.cs
@@ -353,7 +353,20 @@ public class KernelExecutionService(
             };
         }
 
-        // Collect the trailing D integer scalar extents (last int → X, previous → Y, then Z).
+        // Preferred: generator-detected extents (from the kernel's own guard comparisons, e.g.
+        // `x >= width` → width is the X extent). The positional fallback below mis-assigns extents
+        // whenever they are not the trailing parameters — e.g. Mandelbrot(output, width, height,
+        // minX..maxY, maxIterations), whose trailing ints are (maxIterations, height) (GH #182).
+        int DetectedExtent(int dim)
+        {
+            var indices = registration.ExtentParamIndices;
+            return indices is not null && dim < indices.Length && indices[dim] >= 0 && indices[dim] < args.Length
+                && args[indices[dim]] is int detected
+                ? detected
+                : -1;
+        }
+
+        // Fallback: the trailing D integer scalar extents (last int → X, previous → Y, then Z).
         var extents = new List<int>(d);
         for (var i = args.Length - 1; i >= 0 && extents.Count < d; i--)
         {
@@ -363,9 +376,12 @@ public class KernelExecutionService(
             }
         }
 
-        var xExt = extents.Count > 0 ? extents[0] : Math.Max(1, totalWork);
-        var yExt = extents.Count > 1 ? extents[1] : 1;
-        var zExt = extents.Count > 2 ? extents[2] : 1;
+        var xDetected = DetectedExtent(0);
+        var yDetected = DetectedExtent(1);
+        var zDetected = DetectedExtent(2);
+        var xExt = xDetected > 0 ? xDetected : extents.Count > 0 ? extents[0] : Math.Max(1, totalWork);
+        var yExt = yDetected > 0 ? yDetected : extents.Count > 1 ? extents[1] : 1;
+        var zExt = zDetected > 0 ? zDetected : extents.Count > 2 ? extents[2] : 1;
 
         var (bx, by, bz) = d == 2 ? (16u, 16u, 1u) : (8u, 8u, 4u);
 
@@ -521,7 +537,7 @@ public class KernelExecutionService(
         }
 
         var availableAccelerators = _runtime.GetAccelerators()
-            .Where(a => registration.SupportedBackends.Contains(MapDeviceTypeToBackend(a.Info.DeviceType)))
+            .Where(a => IsBackendExecutable(registration, MapDeviceTypeToBackend(a.Info.DeviceType)))
             .ToList();
 
         if (availableAccelerators.Count == 0)
@@ -586,7 +602,7 @@ public class KernelExecutionService(
         }
 
         var supportedAccelerators = _runtime.GetAccelerators()
-            .Where(a => registration.SupportedBackends.Contains(MapDeviceTypeToBackend(a.Info.DeviceType)))
+            .Where(a => IsBackendExecutable(registration, MapDeviceTypeToBackend(a.Info.DeviceType)))
             .ToList();
 
         return supportedAccelerators.AsReadOnly();
@@ -611,11 +627,30 @@ public class KernelExecutionService(
         return await Task.FromResult(true);
     }
 
+    /// <summary>
+    /// True when the kernel carries an executable payload for the backend. The [Kernel] attribute
+    /// may declare CUDA/Metal, but a body the translator could not handle yields no device source —
+    /// such a kernel must not be scheduled (or benchmarked!) as GPU work.
+    /// </summary>
+    private static bool IsBackendExecutable(KernelRegistrationInfo registration, string backend)
+        => registration.SupportedBackends.Contains(backend) && backend switch
+        {
+            "CUDA" => !string.IsNullOrEmpty(registration.CudaSource),
+            "Metal" => !string.IsNullOrEmpty(registration.MetalSource),
+            _ => true,
+        };
+
     private static KernelDefinition CreateKernelDefinition(KernelRegistrationInfo registration, string backend = "CPU")
     {
         var (source, language, entry) = backend switch
         {
-            "CUDA" => (registration.CudaSource ?? GetKernelSource(registration), "CUDA", registration.CudaEntryPoint ?? registration.Name),
+            // No generated CUDA source means the [Kernel] translator could not handle the body.
+            // Feeding the C# placeholder to NVRTC produces a baffling "must contain __global__"
+            // validation error (GH #182 Mandelbrot report) — fail with the real reason instead.
+            "CUDA" => (registration.CudaSource ?? throw new InvalidOperationException(
+                $"Kernel '{registration.FullName ?? registration.Name}' has no generated CUDA source: its body uses C# constructs " +
+                "the [Kernel] CUDA translator does not support yet, so it can only run on the CPU backend. " +
+                "If the kernel body looks translatable, please open an issue with its source."), "CUDA", registration.CudaEntryPoint ?? registration.Name),
             "Metal" => (registration.MetalSource ?? GetKernelSource(registration), "Metal", registration.Name),
             _ => (GetKernelSource(registration), "CSharp", registration.Name),
         };

--- a/src/Runtime/DotCompute.Runtime/Services/KernelExecutionService_Simplified.cs
+++ b/src/Runtime/DotCompute.Runtime/Services/KernelExecutionService_Simplified.cs
@@ -585,6 +585,14 @@ public class KernelRegistrationInfo
     public bool CudaNeedsLength { get; init; }
 
     /// <summary>
+    /// Per-dimension parameter indices supplying the launch extents, detected by the generator
+    /// from the kernel's own guard comparisons (e.g. <c>x &gt;= width</c> maps width to the X
+    /// extent). -1 for undetected dimensions; null when nothing was detected. Positional
+    /// heuristics remain the fallback.
+    /// </summary>
+    public int[]? ExtentParamIndices { get; init; }
+
+    /// <summary>
     /// Generator-emitted CPU invoker: <c>void (KernelArguments args, int start, int end)</c>. It
     /// unpacks the kernel arguments into typed spans/scalars and runs the kernel body over the
     /// half-open work range [start, end). Null when the kernel does not target CPU. This is the

--- a/tests/Unit/DotCompute.Generators.Tests/Generator/KernelExecutionMetadataTests.cs
+++ b/tests/Unit/DotCompute.Generators.Tests/Generator/KernelExecutionMetadataTests.cs
@@ -166,6 +166,91 @@ public struct Index3 { public int X => 0; public int Y => 0; public int Z => 0; 
         Assert.Contains("public static IReadOnlyList<KernelMetadata> GetAllKernels()", registry);
     }
 
+    // The GH #182 reporter's Mandelbrot benchmark kernel: a while-loop body whose extents
+    // (width, height) are NOT the trailing scalars (floats and maxIterations follow them).
+    private const string MandelbrotKernel = @"
+using System;
+namespace TestApp
+{
+    public static class Fractals
+    {
+        [Kernel(Backends = KernelBackends.CPU | KernelBackends.CUDA, VectorSize = 8, IsParallel = true)]
+        public static void Mandelbrot(Span<int> output, int width, int height, float minX, float maxX, float minY, float maxY, int maxIterations)
+        {
+            int x = KernelContext.ThreadId.X;
+            int y = KernelContext.ThreadId.Y;
+
+            if (x >= width || y >= height)
+                return;
+
+            float real = minX + (maxX - minX) * x / (float)width;
+            float imag = minY + (maxY - minY) * y / (float)height;
+
+            float zReal = 0.0f;
+            float zImag = 0.0f;
+            int iterations = 0;
+
+            while (iterations < maxIterations && (zReal * zReal + zImag * zImag) < 4.0f)
+            {
+                float tempReal = zReal * zReal - zImag * zImag + real;
+                zImag = 2.0f * zReal * zImag + imag;
+                zReal = tempReal;
+                iterations++;
+            }
+
+            output[y * width + x] = iterations;
+        }
+    }
+}
+
+[System.AttributeUsage(System.AttributeTargets.Method)]
+public sealed class KernelAttribute : System.Attribute
+{
+    public KernelBackends Backends { get; set; }
+    public int VectorSize { get; set; }
+    public bool IsParallel { get; set; }
+}
+
+[System.Flags]
+public enum KernelBackends { CPU = 1, CUDA = 2, Metal = 4 }
+
+public static class KernelContext
+{
+    public static Index3 ThreadId => default;
+    public static Index3 BlockId => default;
+    public static Index3 BlockDim => default;
+    public static Index3 GridDim => default;
+}
+
+public struct Index3 { public int X => 0; public int Y => 0; public int Z => 0; }
+";
+
+    [Fact]
+    public void Generator_MandelbrotWithWhileLoop_EmitsRealCudaSource()
+    {
+        // Regression for the GH #182 Mandelbrot report: a while-loop body previously produced
+        // CudaSource = null, and an explicit "CUDA" request then failed deep in NVRTC validation.
+        var registry = RunGenerator(MandelbrotKernel).FirstOrDefault(s => s.HintName == "KernelRegistry.g.cs").SourceText?.ToString() ?? string.Empty;
+
+        Assert.DoesNotContain("CudaSource = null", registry);
+        Assert.Contains("__global__ void Mandelbrot(int* output, int width, int height, float minX, float maxX, float minY, float maxY, int maxIterations)", registry);
+        Assert.Contains("while (iterations < maxIterations", registry);
+    }
+
+    [Fact]
+    public void Generator_Mandelbrot_DetectsExtentsFromGuardComparisons()
+    {
+        // width (param 1) bounds x, height (param 2) bounds y — NOT the trailing int scalars
+        // (those are maxIterations and height, which the positional heuristic would pick,
+        // silently computing a wrong region).
+        var registry = RunGenerator(MandelbrotKernel).FirstOrDefault(s => s.HintName == "KernelRegistry.g.cs").SourceText?.ToString() ?? string.Empty;
+
+        Assert.Contains("ExtentParamIndices = new[] { 1, 2 }", registry);
+        // The CPU invoker must use the detected extents for coordinate reconstruction.
+        Assert.Contains("int __xext = (int)args[1];", registry);
+        Assert.Contains("int __yext = (int)args[2];", registry);
+    }
+
     [Fact]
     public void Generator_VectorAddUsingSpanLength_EmitsCudaWithImplicitLengthParameter()
     {

--- a/tests/Unit/DotCompute.Generators.Tests/Generator/KernelExecutionMetadataTests.cs
+++ b/tests/Unit/DotCompute.Generators.Tests/Generator/KernelExecutionMetadataTests.cs
@@ -104,9 +104,11 @@ public struct Index3 { public int X => 0; public int Y => 0; public int Z => 0; 
         // Real CUDA-C, not a placeholder.
         Assert.DoesNotContain("placeholder", registry);
         Assert.Contains("__global__ void TransposeNaive(const float* input, float* output, int rows, int cols)", registry);
-        Assert.Contains("int row = threadIdx.y + blockIdx.y * blockDim.y;", registry);
-        Assert.Contains("int col = threadIdx.x + blockIdx.x * blockDim.x;", registry);
-        Assert.Contains("threadIdx.x", registry);
+        // ThreadId maps to the GLOBAL index, BlockId to 0, BlockDim to the total extent — so the
+        // explicit CUDA-style expression still evaluates to the global coordinate (and bare
+        // ThreadId.X kernels are correct beyond the first block).
+        Assert.Contains("int row = (blockIdx.y * blockDim.y + threadIdx.y) + 0 * (gridDim.y * blockDim.y);", registry);
+        Assert.Contains("int col = (blockIdx.x * blockDim.x + threadIdx.x) + 0 * (gridDim.x * blockDim.x);", registry);
         Assert.Contains("output[col * rows + row] = input[row * cols + col];", registry);
 
         // CUDA entry point = the __global__ function name.
@@ -235,6 +237,7 @@ public struct Index3 { public int X => 0; public int Y => 0; public int Z => 0; 
         Assert.DoesNotContain("CudaSource = null", registry);
         Assert.Contains("__global__ void Mandelbrot(int* output, int width, int height, float minX, float maxX, float minY, float maxY, int maxIterations)", registry);
         Assert.Contains("while (iterations < maxIterations", registry);
+        Assert.Contains("int x = (blockIdx.x * blockDim.x + threadIdx.x);", registry);
     }
 
     [Fact]


### PR DESCRIPTION
Round 6 of #182, from the reporter's Mandelbrot benchmark report (their original kernels now work — this round is about the next kernel they wrote). Three generator/runtime gaps and one **serious latent correctness bug** found while verifying on an A10.

## 1. Loop kernels now translate to CUDA

The `[Kernel]` CUDA translator had no loop support — any `while`/`for` body yielded `CudaSource = null`. Added `while` / `do` / `for` / `break` / `continue` translation. The reporter's exact Mandelbrot kernel now generates real CUDA-C.

## 2. `ThreadId` now maps to the GLOBAL thread index (latent correctness bug)

The `[Kernel]` model (docs + CPU invoker) defines `ThreadId` as the global coordinate, but CUDA translation emitted block-local `threadIdx` — **every CUDA block computed the same tile**. On the A10, Mandelbrot produced exactly 256 correct pixels (one 16×16 block); 1-D kernels like the reporter's `Add` were only correct within the first block — our earlier 4-element verifications masked this completely. `ThreadId` now maps to `(blockIdx*blockDim + threadIdx)`, `BlockId` to `0`, `BlockDim` to the total extent — mirroring CPU semantics, so bare-`ThreadId.X` kernels *and* explicit `ThreadId.X + BlockId.X * BlockDim.X` kernels both yield the global index.

## 3. Launch extents from the kernel's own guards

Extents were taken positionally (trailing int scalars). Mandelbrot's signature `(output, width, height, minX..maxY, maxIterations)` puts floats and `maxIterations` after the extents → the heuristic picked `(maxIterations, height)`, silently computing a wrong region on CPU and a wrong grid on CUDA. The generator now detects extents from guard comparisons (`x >= width` ⇒ width is the X extent), emits `ExtentParamIndices` into the registry, and both the CPU invoker and the runtime launch use them (positional fallback preserved; TransposeNaive maps identically to before).

## 4. Honest errors + honest backend lists

An explicit `"CUDA"` request for an untranslatable kernel fed a C# placeholder to NVRTC → baffling *"CUDA source must contain at least one __global__ function"*. Now: `CreateKernelDefinition` fails with the real reason, and backend eligibility (optimal selection + `GetSupportedAcceleratorsAsync`) requires an actual payload for CUDA/Metal — important for benchmarks, where a silent CPU fallback would fake GPU numbers.

## Verification (A10, CUDA 12.8, fresh clone)

```
Add       n=1,048,576 (thousands of blocks)  CPU ✓  CUDA ✓
Transpose 300×500 (explicit-index style)     CPU ✓  CUDA ✓
Mandelbrot 1920×1080×1000 (reporter's exact) CPU ✓  CUDA ✓  (99.65% exact pixel match, rest FMA boundary drift ≤ tolerance)
```

401 generator + 147 runtime tests green (new tests: Mandelbrot translates with the while loop; extents detect as `{width, height}`; CPU invoker uses them); solution builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
